### PR TITLE
feat: centralise tunables config

### DIFF
--- a/src/renderer/manufacturing/data/campaigns.ts
+++ b/src/renderer/manufacturing/data/campaigns.ts
@@ -1,4 +1,5 @@
 import { AdCampaign } from "../types";
+import { CAMPAIGN_COST_INFLATION, CAMPAIGN_BASE_YEAR } from "../../../simulation/tunables";
 
 export const AD_CAMPAIGNS: AdCampaign[] = [
   {
@@ -38,11 +39,8 @@ export const AD_CAMPAIGNS: AdCampaign[] = [
   },
 ];
 
-export const CAMPAIGN_COST_INFLATION = 1.03;
-export const BASE_YEAR = 2000;
-
 export function getCampaignCost(campaign: AdCampaign, year: number): number {
-  const yearsElapsed = year - BASE_YEAR;
+  const yearsElapsed = year - CAMPAIGN_BASE_YEAR;
   return Math.round(campaign.baseCost * Math.pow(CAMPAIGN_COST_INFLATION, yearsElapsed));
 }
 

--- a/src/renderer/manufacturing/utils/constants.ts
+++ b/src/renderer/manufacturing/utils/constants.ts
@@ -1,32 +1,18 @@
-import { ModelType } from "../../state/gameTypes";
-
-export const REFERENCE_QUANTITY = 5_000;
-export const MULTI_MODEL_OVERHEAD = 500_000;
-export const DEMAND_NOISE_MIN = 10;
-export const DEMAND_NOISE_MAX = 15;
-export const MIN_BATCH_SIZE = 1_000;
-export const MAX_PRICE_MULTIPLIER = 4;
-
-// Per-unit cost layers (flat, on top of BOM)
-export const ASSEMBLY_QA_COST = 10;
-export const PACKAGING_LOGISTICS_COST = 15;
-
-// Channel margin — retailer takes this % of retail price
-export const CHANNEL_MARGIN_RATE = 0.20;
-
-// Support budget slider range
-export const SUPPORT_BUDGET_MIN = 0;
-export const SUPPORT_BUDGET_MAX = 50;
-
-// Fixed costs by model type
-export const TOOLING_COST: Record<ModelType, number> = {
-  brandNew: 800_000,
-  successor: 300_000,
-  specBump: 0,
-};
-
-export const CERTIFICATION_COST: Record<ModelType, number> = {
-  brandNew: 50_000,
-  successor: 50_000,
-  specBump: 0,
-};
+/**
+ * Re-exports from centralised tunables for backwards-compatible imports.
+ */
+export {
+  REFERENCE_QUANTITY,
+  MULTI_MODEL_OVERHEAD,
+  DEMAND_NOISE_MIN,
+  DEMAND_NOISE_MAX,
+  MIN_BATCH_SIZE,
+  MAX_PRICE_MULTIPLIER,
+  ASSEMBLY_QA_COST,
+  PACKAGING_LOGISTICS_COST,
+  CHANNEL_MARGIN_RATE,
+  SUPPORT_BUDGET_MIN,
+  SUPPORT_BUDGET_MAX,
+  TOOLING_COST,
+  CERTIFICATION_COST,
+} from "../../../simulation/tunables";

--- a/src/simulation/brandProgression.ts
+++ b/src/simulation/brandProgression.ts
@@ -10,27 +10,21 @@ import { GameState, CompetitorState } from "../renderer/state/gameTypes";
 import { YearSimulationResult } from "./salesTypes";
 import { computeStatsForDesign } from "./statCalculation";
 import { getPriceCeiling } from "./demographicData";
+import {
+  S_CURVE_STEEPNESS,
+  S_CURVE_MIDPOINT,
+  AWARENESS_DIVISOR,
+  WOM_DIVISOR,
+  CAMPAIGN_DIVISOR,
+  CAMPAIGN_IMMEDIATE_REACH_DIVISOR,
+  PERCEPTION_CONTRIBUTION_SCALE,
+  REACH_INACTIVITY_DECAY,
+  COMPETITOR_TIME_IN_MARKET_BONUS,
+  PERCEPTION_DECAY,
+  NEGATIVITY_MULTIPLIER,
+} from "./tunables";
 
 // ==================== Brand Reach ====================
-
-/** S-curve steepness — higher = steeper transition in the middle */
-const S_CURVE_STEEPNESS = 0.08;
-/** S-curve midpoint (reach % where growth is fastest) */
-const S_CURVE_MIDPOINT = 50;
-/** Awareness budget divisor — every $X of awareness budget contributes 1 raw reach point */
-const AWARENESS_BUDGET_DIVISOR = 500_000;
-/** Word-of-mouth divisor — every X units sold in a demographic contributes 1 raw reach point */
-const WORD_OF_MOUTH_DIVISOR = 5_000;
-/** Marketing campaign divisor — every $X of campaign spend contributes 1 raw reach point (S-curve, year-over-year) */
-const CAMPAIGN_REACH_DIVISOR = 2_000_000;
-/** Immediate reach divisor — every $X of campaign spend gives 1% immediate reach (flat, same-year) */
-const CAMPAIGN_IMMEDIATE_REACH_DIVISOR = 500_000;
-/** Scales raw value-for-money contribution into perception points (roughly ±5 per year) */
-const PERCEPTION_CONTRIBUTION_SCALE = 5;
-/** Reach decay rate when no products on sale (proportional, per year) */
-const REACH_INACTIVITY_DECAY = 0.10;
-/** Competitor time-in-market reach growth (raw reach points per year just for existing) */
-const COMPETITOR_TIME_IN_MARKET_BONUS = 0.5;
 
 /**
  * Logistic S-curve growth factor.
@@ -104,7 +98,7 @@ export function updateBrandReach(
     let rawGrowth = 0;
 
     // 1. Awareness budget — small uniform push across all demographics
-    rawGrowth += state.brandAwarenessBudget / AWARENESS_BUDGET_DIVISOR;
+    rawGrowth += state.brandAwarenessBudget / AWARENESS_DIVISOR;
 
     // 2. Sponsorships — targeted boosts
     for (const sponsorshipId of state.sponsorships) {
@@ -116,10 +110,10 @@ export function updateBrandReach(
 
     // 3. Word of mouth — organic from units sold in this demographic
     const unitsSold = unitsByDemographic[demId] ?? 0;
-    rawGrowth += unitsSold / WORD_OF_MOUTH_DIVISOR;
+    rawGrowth += unitsSold / WOM_DIVISOR;
 
     // 4. Marketing campaigns — secondary reach from ad spend (uniform across demographics)
-    rawGrowth += totalCampaignSpend / CAMPAIGN_REACH_DIVISOR;
+    rawGrowth += totalCampaignSpend / CAMPAIGN_DIVISOR;
 
     // Apply S-curve: growth is modulated by current reach position
     const growth = rawGrowth * sCurveGrowthFactor(current) * 100;
@@ -160,7 +154,7 @@ export function updateCompetitorBrandReach(
 
     // Competitor reach growth from sales + time-in-market
     const unitsSold = unitsByDemographic[demId] ?? 0;
-    const rawGrowth = unitsSold / WORD_OF_MOUTH_DIVISOR + COMPETITOR_TIME_IN_MARKET_BONUS;
+    const rawGrowth = unitsSold / WOM_DIVISOR + COMPETITOR_TIME_IN_MARKET_BONUS;
     const growth = rawGrowth * sCurveGrowthFactor(current) * 100;
 
     newReach[demId] = Math.max(0, Math.min(100, current + growth));
@@ -170,11 +164,6 @@ export function updateCompetitorBrandReach(
 }
 
 // ==================== Brand Perception ====================
-
-/** Perception decay factor (50% fade per year — recency bias) */
-const PERCEPTION_DECAY = 0.5;
-/** Negativity bias multiplier — bad value-for-money hits harder */
-const NEGATIVITY_BIAS = 1.5;
 
 /**
  * Update per-demographic brand perception based on value-for-money of products sold.
@@ -214,7 +203,7 @@ export function updateBrandPerception(
       const priceRatio = model.retailPrice / ceiling;
 
       const valueForMoney = statScore - priceRatio;
-      const adjusted = valueForMoney < 0 ? valueForMoney * NEGATIVITY_BIAS : valueForMoney;
+      const adjusted = valueForMoney < 0 ? valueForMoney * NEGATIVITY_MULTIPLIER : valueForMoney;
 
       contributionByDem[dem.id] = (contributionByDem[dem.id] ?? 0) + adjusted * db.unitsDemanded;
       weightByDem[dem.id] = (weightByDem[dem.id] ?? 0) + db.unitsDemanded;

--- a/src/simulation/demographicData.ts
+++ b/src/simulation/demographicData.ts
@@ -1,5 +1,6 @@
 import { DemographicId } from "../data/types";
 import { PriceCeiling, DemandGrowthAnchor } from "./salesTypes";
+import { PRICE_INFLATION_RATE, PRICE_BASE_YEAR } from "./tunables";
 
 // --- Price Ceilings (year-2000 baseline, inflates ~3% per year) ---
 
@@ -13,9 +14,6 @@ export const PRICE_CEILINGS: PriceCeiling[] = [
   { demographicId: "gamer", baseCeiling: 2000 },
   { demographicId: "creativeProfessional", baseCeiling: 2500 },
 ];
-
-export const PRICE_INFLATION_RATE = 1.03;
-export const PRICE_BASE_YEAR = 2000;
 
 export function getPriceCeiling(demographicId: DemographicId, year: number): number {
   const entry = PRICE_CEILINGS.find((p) => p.demographicId === demographicId);

--- a/src/simulation/salesEngine.ts
+++ b/src/simulation/salesEngine.ts
@@ -24,7 +24,10 @@ import {
   CHANNEL_MARGIN_RATE,
   DEMAND_NOISE_MIN,
   DEMAND_NOISE_MAX,
-} from "../renderer/manufacturing/utils/constants";
+  PRICE_OVERSHOOT_DECAY,
+  BASE_DEMAND_VARIANCE,
+  REACH_VARIANCE_SCALE,
+} from "./tunables";
 import { AD_CAMPAIGNS } from "../renderer/manufacturing/data/campaigns";
 import { generateCompetitorModels } from "./competitorAI";
 import { COMPETITORS } from "../data/competitors";
@@ -39,15 +42,6 @@ export function clearProjectionCache(): void {
   cachedProjectionYear = null;
   cachedProjectionModels = [];
 }
-
-// --- Tuning Constants ---
-
-/** Exponential decay rate for price overshoot above ceiling */
-const PRICE_OVERSHOOT_DECAY = 3;
-/** Base demand variance for projections */
-const BASE_DEMAND_VARIANCE = 0.15;
-/** Additional variance scaled by average reach */
-const REACH_VARIANCE_SCALE = 0.20;
 
 // --- Market Entry: all laptops competing this year ---
 

--- a/src/simulation/tunables.ts
+++ b/src/simulation/tunables.ts
@@ -1,0 +1,124 @@
+/**
+ * Centralised tunables config.
+ * All game-balance constants live here so designers can tweak one file.
+ * See GDD § "Tunables (centralised in config)" for reference values.
+ */
+
+import { DemographicId } from "../data/types";
+import { ModelType } from "../renderer/state/gameTypes";
+
+// ==================== Brand Reach ====================
+
+/** S-curve steepness — higher = steeper transition in the middle */
+export const S_CURVE_STEEPNESS = 0.08;
+/** S-curve midpoint (reach % where growth is fastest) */
+export const S_CURVE_MIDPOINT = 50;
+/** Awareness budget divisor — every $X of awareness budget contributes 1 raw reach point */
+export const AWARENESS_DIVISOR = 500_000;
+/** Word-of-mouth divisor — every X units sold contributes 1 raw reach point */
+export const WOM_DIVISOR = 5_000;
+/** Marketing campaign divisor — every $X of campaign spend contributes 1 raw reach point (S-curve, year-over-year) */
+export const CAMPAIGN_DIVISOR = 2_000_000;
+/** Immediate reach divisor — every $X of campaign spend gives 1% immediate reach (flat, same-year) */
+export const CAMPAIGN_IMMEDIATE_REACH_DIVISOR = 500_000;
+/** Reach decay rate when no products on sale (proportional, per year) */
+export const REACH_INACTIVITY_DECAY = 0.10;
+/** Competitor time-in-market reach growth (raw reach points per year just for existing) */
+export const COMPETITOR_TIME_IN_MARKET_BONUS = 0.5;
+
+// ==================== Brand Perception ====================
+
+/** Scales raw value-for-money contribution into perception points (roughly +-5 per year) */
+export const PERCEPTION_CONTRIBUTION_SCALE = 5;
+/** Perception decay factor (50% fade per year — recency bias) */
+export const PERCEPTION_DECAY = 0.5;
+/** Negativity bias multiplier — bad value-for-money hits harder */
+export const NEGATIVITY_MULTIPLIER = 1.5;
+
+// ==================== Sales Engine ====================
+
+/** Exponential decay rate for price overshoot above ceiling */
+export const PRICE_OVERSHOOT_DECAY = 3;
+/** Base demand variance for projections */
+export const BASE_DEMAND_VARIANCE = 0.15;
+/** Additional variance scaled by average reach */
+export const REACH_VARIANCE_SCALE = 0.20;
+/** Demand noise floor (percentage) */
+export const DEMAND_NOISE_MIN = 10;
+/** Demand noise ceiling (percentage) */
+export const DEMAND_NOISE_MAX = 15;
+/** Channel margin — retailer takes this fraction of retail price */
+export const CHANNEL_MARGIN_RATE = 0.20;
+
+// ==================== Pricing ====================
+
+/** Annual price-ceiling inflation rate */
+export const PRICE_INFLATION_RATE = 1.03;
+/** Baseline year for inflation calculations */
+export const PRICE_BASE_YEAR = 2000;
+
+// ==================== Campaign Costs ====================
+
+/** Annual scaling for campaign and sponsorship costs */
+export const CAMPAIGN_COST_INFLATION = 1.03;
+/** Base year for campaign cost inflation */
+export const CAMPAIGN_BASE_YEAR = 2000;
+
+// ==================== Manufacturing ====================
+
+/** Reference quantity for economies-of-scale calculation */
+export const REFERENCE_QUANTITY = 5_000;
+/** Fixed overhead for running 2+ distinct models */
+export const MULTI_MODEL_OVERHEAD = 500_000;
+/** Minimum manufacturing batch size */
+export const MIN_BATCH_SIZE = 1_000;
+/** Maximum price multiplier over unit cost */
+export const MAX_PRICE_MULTIPLIER = 4;
+/** Per-unit assembly/QA cost */
+export const ASSEMBLY_QA_COST = 10;
+/** Per-unit packaging/logistics cost */
+export const PACKAGING_LOGISTICS_COST = 15;
+/** Support budget slider minimum */
+export const SUPPORT_BUDGET_MIN = 0;
+/** Support budget slider maximum */
+export const SUPPORT_BUDGET_MAX = 50;
+
+/** Fixed tooling cost by model type */
+export const TOOLING_COST: Record<ModelType, number> = {
+  brandNew: 800_000,
+  successor: 300_000,
+  specBump: 0,
+};
+
+/** Fixed certification cost by model type */
+export const CERTIFICATION_COST: Record<ModelType, number> = {
+  brandNew: 50_000,
+  successor: 50_000,
+  specBump: 0,
+};
+
+// ==================== Demographic Replacement Cycles ====================
+
+/** Years between upgrades, per demographic */
+export const REPLACEMENT_CYCLE: Record<DemographicId, number> = {
+  techEnthusiast: 2,
+  businessProfessional: 3,
+  student: 3,
+  creativeProfessional: 3,
+  gamer: 3,
+  generalConsumer: 3,
+  corporate: 4,
+  budgetBuyer: 5,
+};
+
+// ==================== Quarterly Distribution ====================
+
+/** Buyer distribution across Q1-Q4 (out of sum = 15) */
+export const QUARTER_SHARES = [8, 4, 2, 1] as const;
+
+// ==================== Awards ====================
+
+/** Global perception boost from winning an award */
+export const AWARD_PERCEPTION_BONUS = 2;
+/** Global reach % boost from winning an award */
+export const AWARD_REACH_BONUS = 1;


### PR DESCRIPTION
## Summary
- Creates `src/simulation/tunables.ts` containing all configurable game-balance constants in one file (brand reach, perception, sales, pricing, campaigns, manufacturing, replacement cycles, quarter shares, awards)
- Migrates constants from `brandProgression.ts`, `salesEngine.ts`, `demographicData.ts`, `campaigns.ts`, and `manufacturing/utils/constants.ts` to the new centralised file
- Updates all imports across the codebase — existing files either import directly from tunables or re-export for backwards compatibility
- Aligns constant names with GDD tunables table (e.g. `WOM_DIVISOR`, `CAMPAIGN_DIVISOR`, `AWARENESS_DIVISOR`, `NEGATIVITY_MULTIPLIER`)
- Adds not-yet-implemented GDD tunables: `REPLACEMENT_CYCLE` per demographic, `QUARTER_SHARES`, `AWARD_PERCEPTION_BONUS`, `AWARD_REACH_BONUS`

Closes #53 subtask 7.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `yarn lint` passes
- [ ] Verify game runs and sales simulation produces same results as before