### PR TITLE
feat: add sponsorship cost inflation (#53 subtask 6)

### DIFF
--- a/src/data/sponsorships.ts
+++ b/src/data/sponsorships.ts
@@ -1,4 +1,5 @@
 import { DemographicId } from "./types";
+import { getInflatedCost } from "../simulation/costInflation";
 
 export interface Sponsorship {
   id: string;
@@ -91,3 +92,8 @@ export const SPONSORSHIPS: Sponsorship[] = [
     },
   },
 ];
+
+/** Get the inflation-adjusted cost of a sponsorship for a given year. */
+export function getSponsorshipCost(sponsorship: Sponsorship, year: number): number {
+  return getInflatedCost(sponsorship.baseCost, year);
+}

--- a/src/renderer/manufacturing/data/campaigns.ts
+++ b/src/renderer/manufacturing/data/campaigns.ts
@@ -1,5 +1,5 @@
 import { AdCampaign } from "../types";
-import { CAMPAIGN_COST_INFLATION, CAMPAIGN_BASE_YEAR } from "../../../simulation/tunables";
+import { getInflatedCost } from "../../../simulation/costInflation";
 
 export const AD_CAMPAIGNS: AdCampaign[] = [
   {
@@ -40,8 +40,7 @@ export const AD_CAMPAIGNS: AdCampaign[] = [
 ];
 
 export function getCampaignCost(campaign: AdCampaign, year: number): number {
-  const yearsElapsed = year - CAMPAIGN_BASE_YEAR;
-  return Math.round(campaign.baseCost * Math.pow(CAMPAIGN_COST_INFLATION, yearsElapsed));
+  return getInflatedCost(campaign.baseCost, year);
 }
 
 export function getRiskLabel(campaign: AdCampaign): string {

--- a/src/simulation/costInflation.ts
+++ b/src/simulation/costInflation.ts
@@ -1,0 +1,10 @@
+import { CAMPAIGN_COST_INFLATION, CAMPAIGN_BASE_YEAR } from "./tunables";
+
+/**
+ * Apply annual cost inflation to a base cost.
+ * Formula: base_cost × CAMPAIGN_COST_INFLATION ^ (year - CAMPAIGN_BASE_YEAR)
+ */
+export function getInflatedCost(baseCost: number, year: number): number {
+  const yearsElapsed = year - CAMPAIGN_BASE_YEAR;
+  return Math.round(baseCost * Math.pow(CAMPAIGN_COST_INFLATION, yearsElapsed));
+}


### PR DESCRIPTION
## Summary
- Extract shared `getInflatedCost(baseCost, year)` utility in `src/simulation/costInflation.ts` using `CAMPAIGN_COST_INFLATION` and `CAMPAIGN_BASE_YEAR` from tunables
- Refactor `getCampaignCost` in `campaigns.ts` to use the shared utility (no behavior change)
- Add `getSponsorshipCost(sponsorship, year)` in `sponsorships.ts` that applies the same inflation formula: `baseCost × 1.03^(year - 2000)`

## Test plan
- [ ] Verify `getCampaignCost` still produces identical results after refactor
- [ ] Verify `getSponsorshipCost` returns inflated costs (e.g. $150K base in year 2025 → $150K × 1.03^25 ≈ $314K)
- [ ] Confirm `tsc --noEmit` and `yarn lint` pass cleanly