### PR TITLE
feat: per-demographic price sensitivity in sales simulation

### DIFF
--- a/laptop-tycoon-gdd.md
+++ b/laptop-tycoon-gdd.md
@@ -230,8 +230,19 @@ For each stat:
 
 weighted_score = dot_product(normalized_stats, demographic_weight_vector)
 screen_penalty = screen size fit penalty (1.0 if preferred, 0.5 if one class off, 0.1 if two+ off)
-raw_vp = (weighted_score × screen_penalty) / price
+sensitivity_factor = PRICE_SENSITIVITY_EXPONENT[demographic.priceSensitivity]
+raw_vp = (weighted_score × screen_penalty) / price ^ sensitivity_factor
 ```
+
+**Price sensitivity exponent** varies by demographic. At `moderate` (1.0) the formula behaves as a simple inverse. Lower exponents (Corporate, Creative Professional) make the demographic more tolerant of high prices — enabling high-margin niche strategies. Higher exponents (Student, Budget Buyer) punish price increases more steeply — these segments flock to whoever is cheapest.
+
+| Sensitivity Level | Exponent | Demographics |
+|-------------------|----------|-------------|
+| low | 0.8 | Corporate, Creative Professional |
+| moderate | 1.0 | Business Professional, Gamer, Tech Enthusiast |
+| high | 1.2 | General Consumer |
+| veryHigh | 1.4 | Student |
+| extreme | 1.6 | Budget Buyer |
 
 ### Step 2: Biased Value Proposition
 
@@ -557,6 +568,7 @@ Both player and AI competitors use this interface. The simulation iterates over 
 
 | Constant | Starting Value | Notes |
 |----------|---------------|-------|
+| PRICE_SENSITIVITY_EXPONENT | low=0.8, moderate=1.0, high=1.2, veryHigh=1.4, extreme=1.6 | Exponent on price in raw VP formula per demographic sensitivity level |
 | WOM_DIVISOR | TBD | Units sold per 1 raw reach point from word of mouth |
 | CAMPAIGN_DIVISOR | 2,000,000 | Campaign spend per 1 raw reach point |
 | AWARENESS_DIVISOR | 500,000 | Awareness budget spend per 1 raw reach point |

--- a/src/simulation/salesEngine.ts
+++ b/src/simulation/salesEngine.ts
@@ -28,6 +28,7 @@ import {
   REPLACEMENT_CYCLE,
   QUARTER_SHARES,
   QUARTER_SHARES_SUM,
+  PRICE_SENSITIVITY_EXPONENT,
 } from "./tunables";
 import { AD_CAMPAIGNS } from "../renderer/manufacturing/data/campaigns";
 import { sampleCampaignOutcome } from "../renderer/manufacturing/utils/skewNormal";
@@ -201,8 +202,9 @@ function calculateBiasedVP(
   const pref = demographic.screenSizePreference;
   const screenPenalty = getScreenSizeFit(laptop.model.design.screenSize, pref.preferredMin, pref.preferredMax, pref.penaltyPerInch);
 
-  // Step 1: raw_vp = (weighted_score × screen_penalty) / price
-  const rawVP = (weightedStatScore * screenPenalty) / laptop.retailPrice;
+  // Step 1: raw_vp = (weighted_score × screen_penalty) / price ^ sensitivity_factor
+  const sensitivityExponent = PRICE_SENSITIVITY_EXPONENT[demographic.priceSensitivity];
+  const rawVP = (weightedStatScore * screenPenalty) / Math.pow(laptop.retailPrice, sensitivityExponent);
 
   // Step 2: biased_vp = raw_vp × (1 + brand_perception_mod / 100) × (1 + laptop_perception_mod / 100)
   const company = state.companies.find((c) => c.id === laptop.owner);

--- a/src/simulation/tunables.ts
+++ b/src/simulation/tunables.ts
@@ -39,6 +39,21 @@ export const PERCEPTION_MIN = -50;
 /** Perception ceiling (maximum per-demographic perception score) */
 export const PERCEPTION_MAX = 50;
 
+// ==================== Price Sensitivity ====================
+
+import { PriceSensitivity } from "../data/types";
+
+/** Exponent on price in the raw VP formula, per demographic price sensitivity level.
+ *  raw_vp = (weighted_score × screen_penalty) / price ^ exponent
+ *  moderate (1.0) = baseline (same as simple inverse). Lower = more price-tolerant, higher = more price-sensitive. */
+export const PRICE_SENSITIVITY_EXPONENT: Record<PriceSensitivity, number> = {
+  low: 0.8,
+  moderate: 1.0,
+  high: 1.2,
+  veryHigh: 1.4,
+  extreme: 1.6,
+};
+
 // ==================== Sales Engine ====================
 
 /** Base demand variance for projections */


### PR DESCRIPTION
## Summary
- Activates the existing `priceSensitivity` field on demographics by applying it as an exponent on price in the raw VP formula: `raw_vp = (weighted_score × screen_penalty) / price ^ sensitivity_factor`
- Adds `PRICE_SENSITIVITY_EXPONENT` mapping to tunables (low=0.8, moderate=1.0, high=1.2, veryHigh=1.4, extreme=1.6)
- Documents the formula and exponent table in the GDD

## Test plan
- [ ] Playtest: verify Budget Buyers strongly prefer cheapest laptop
- [ ] Playtest: verify Creative Professionals tolerate premium pricing better than before
- [ ] Verify moderate (1.0) demographics behave identically to pre-change

Closes #61
Closes #59