### PR TITLE
refactor: move shared constants from renderer/wizard to data/ (#42)

### DIFF
--- a/src/data/designConstants.ts
+++ b/src/data/designConstants.ts
@@ -1,16 +1,16 @@
-import { ChassisOption, ChassisOptionSlot, Component, ComponentSlot, ScreenSizeInches } from "../../data/types";
-import { PORT_TYPES } from "../../data/portTypes";
-import { ALL_COMPONENTS } from "../../data/components";
-import { COLOUR_OPTIONS } from "../../data/colourOptions";
-import { getScreenSizeDef } from "../../data/screenSizes";
-import { getBatteryEra } from "../../data/batteryEras";
-import { SLOT_CONFIGS } from "../../data/slotConfigs";
+import { ChassisOption, ChassisOptionSlot, Component, ComponentSlot, ScreenSizeInches } from "./types";
+import { PORT_TYPES } from "./portTypes";
+import { ALL_COMPONENTS } from "./components";
+import { COLOUR_OPTIONS } from "./colourOptions";
+import { getScreenSizeDef } from "./screenSizes";
+import { getBatteryEra } from "./batteryEras";
+import { SLOT_CONFIGS } from "./slotConfigs";
 import {
   MATERIALS,
   COOLING_SOLUTIONS,
   KEYBOARD_FEATURES,
   TRACKPAD_FEATURES,
-} from "../../data/chassisOptions";
+} from "./chassisOptions";
 
 export const MIN_BATTERY_WH = 20;
 export const MAX_BATTERY_WH = 100;

--- a/src/renderer/wizard/DesignWizard.tsx
+++ b/src/renderer/wizard/DesignWizard.tsx
@@ -7,7 +7,7 @@ import {
   totalConsumedVolumeCm3,
   maxHeightConstraintCm,
   computeLaptopTotals,
-} from "./constants";
+} from "../../data/designConstants";
 import { useGame } from "../state/GameContext";
 import { useNavigation } from "../navigation/NavigationContext";
 import { LaptopDesign } from "../state/gameTypes";

--- a/src/renderer/wizard/LaptopEstimateSidebar.tsx
+++ b/src/renderer/wizard/LaptopEstimateSidebar.tsx
@@ -11,7 +11,7 @@ import {
   batteryWarningThresholdH,
   avgUsageMultiplier,
   computeLaptopTotals,
-} from "./constants";
+} from "../../data/designConstants";
 import { getScreenSizeDef } from "../../data/screenSizes";
 import { getAllChassisOptions } from "./types";
 import { STAT_CONFIG, computeStatTotals, getStatColor } from "./StatBar";

--- a/src/renderer/wizard/WizardContext.tsx
+++ b/src/renderer/wizard/WizardContext.tsx
@@ -16,7 +16,7 @@ import {
 } from "../../data/types";
 import { LaptopDesign } from "../state/gameTypes";
 import { useGame } from "../state/GameContext";
-import { getAvailableComponents, getAvailableChassisOptions, CHASSIS_SLOTS } from "./constants";
+import { getAvailableComponents, getAvailableChassisOptions, CHASSIS_SLOTS } from "../../data/designConstants";
 import { COLOUR_OPTIONS } from "../../data/colourOptions";
 
 type WizardAction =

--- a/src/renderer/wizard/steps/BatteryStep.tsx
+++ b/src/renderer/wizard/steps/BatteryStep.tsx
@@ -1,5 +1,5 @@
 import { useWizard } from "../WizardContext";
-import { formatWeight, MIN_BATTERY_WH, MAX_BATTERY_WH, BATTERY_STEP_WH, avgUsageMultiplier, batteryWarningThresholdH, applyDisplayMultiplier } from "../constants";
+import { formatWeight, MIN_BATTERY_WH, MAX_BATTERY_WH, BATTERY_STEP_WH, avgUsageMultiplier, batteryWarningThresholdH, applyDisplayMultiplier } from "../../../data/designConstants";
 import { getBatteryEra } from "../../../data/batteryEras";
 import { getScreenSizeDef } from "../../../data/screenSizes";
 import { StatCard } from "./StatCard";

--- a/src/renderer/wizard/steps/BodyStep.tsx
+++ b/src/renderer/wizard/steps/BodyStep.tsx
@@ -14,7 +14,7 @@ import {
   specSummary,
   CHASSIS_SLOTS,
   getAvailableChassisOptions,
-} from "../constants";
+} from "../../../data/designConstants";
 import { ChassisOption } from "../../../data/types";
 import { getAllChassisOptions } from "../types";
 import { Tooltip } from "../Tooltip";

--- a/src/renderer/wizard/steps/ComponentStepLayout.tsx
+++ b/src/renderer/wizard/steps/ComponentStepLayout.tsx
@@ -1,5 +1,5 @@
 import { useWizard } from "../WizardContext";
-import { DISPLAY_SLOTS, applyDisplayMultiplier, specSummary, getAvailableComponents, componentCostDecayed } from "../constants";
+import { DISPLAY_SLOTS, applyDisplayMultiplier, specSummary, getAvailableComponents, componentCostDecayed } from "../../../data/designConstants";
 import { getScreenSizeDef } from "../../../data/screenSizes";
 import { Component, ComponentSlot, ScreenSizeDefinition } from "../../../data/types";
 import { Tooltip } from "../Tooltip";

--- a/src/renderer/wizard/steps/ReviewEditDialog.tsx
+++ b/src/renderer/wizard/steps/ReviewEditDialog.tsx
@@ -21,7 +21,7 @@ import {
   minThicknessForVolumeCm,
   getAvailableComponents,
   getAvailableChassisOptions,
-} from "../constants";
+} from "../../../data/designConstants";
 import { getAllChassisOptions } from "../types";
 import { getScreenSizeDef, SCREEN_SIZES } from "../../../data/screenSizes";
 import { getBatteryEra } from "../../../data/batteryEras";

--- a/src/renderer/wizard/steps/ReviewStep.tsx
+++ b/src/renderer/wizard/steps/ReviewStep.tsx
@@ -15,7 +15,7 @@ import {
   CHASSIS_SLOTS,
   computeLaptopTotals,
   componentCostDecayed,
-} from "../constants";
+} from "../../../data/designConstants";
 import { getAllChassisOptions, WIZARD_STEP_LABELS, WIZARD_STEPS, COMPONENT_STEP_SLOTS, WizardStep } from "../types";
 import { getScreenSizeDef } from "../../../data/screenSizes";
 import { getBatteryEra } from "../../../data/batteryEras";

--- a/src/renderer/wizard/steps/ScreenSizeStep.tsx
+++ b/src/renderer/wizard/steps/ScreenSizeStep.tsx
@@ -1,5 +1,5 @@
 import { useWizard } from "../WizardContext";
-import { formatWeight } from "../constants";
+import { formatWeight } from "../../../data/designConstants";
 import { tokens } from "../../shell/tokens";
 import { SCREEN_SIZES, getScreenSizeDef } from "../../../data/screenSizes";
 import { StatCard } from "./StatCard";

--- a/src/renderer/wizard/types.ts
+++ b/src/renderer/wizard/types.ts
@@ -10,7 +10,7 @@ import {
   MIN_BATTERY_WH,
   THICKNESS_DEFAULT_CM,
   BEZEL_DEFAULT_MM,
-} from "./constants";
+} from "../../data/designConstants";
 
 export type WizardStep =
   | "metadata"

--- a/src/simulation/competitorAI.ts
+++ b/src/simulation/competitorAI.ts
@@ -15,7 +15,7 @@ import {
   THICKNESS_STEP_CM,
   BEZEL_MIN_MM,
   BEZEL_MAX_MM,
-} from "../renderer/wizard/constants";
+} from "../data/designConstants";
 import {
   MATERIALS,
   COOLING_SOLUTIONS,

--- a/src/simulation/statCalculation.ts
+++ b/src/simulation/statCalculation.ts
@@ -27,7 +27,7 @@ import {
   coolingMultiplier,
   availableVolumeCm3,
   totalConsumedVolumeCm3,
-} from "../renderer/wizard/constants";
+} from "../data/designConstants";
 
 export interface RawStatTotalsParams {
   screenSize: ScreenSizeInches;


### PR DESCRIPTION
## Summary
- Moved `src/renderer/wizard/constants.ts` → `src/data/designConstants.ts` to fix inverted dependency (simulation code was importing from renderer/wizard)
- Updated all 12 import paths across simulation and renderer files
- No logic changes — pure file move + import path updates

Closes #42

## Test plan
- [x] `tsc --noEmit` passes
- [x] `yarn lint` passes
- [ ] App loads and design wizard works normally