### PR TITLE
Fix reach-gated demand pools + surface brand spend (#76)

### DIFF
--- a/laptop-tycoon-gdd.md
+++ b/laptop-tycoon-gdd.md
@@ -278,14 +278,15 @@ Replacement cycle varies by demographic:
 Everyone in the active buyer pool WILL buy a laptop. There is no "don't buy" option in the probability distribution. The replacement cycle already filters out people who aren't in the market this year.
 
 ```
-addressable_pool = quarterly_active_buyers × (brand_reach[demographic] / 100)
+For each company's laptop(s):
+  effective_vp = biased_vp × (brand_reach[demographic] / 100)
 
-For each company's laptop(s) in this demographic's addressable pool:
-  purchase_probability = biased_vp / sum(all biased_vps)
-
-units_demanded = addressable_pool × purchase_probability
+purchase_probability = effective_vp / sum(all effective_vps across all companies)
+units_demanded = quarterly_active_buyers × purchase_probability
 units_sold = min(units_demanded, units_remaining_in_manufacturing_order)
 ```
+
+Reach is a multiplier on competitive strength, not a gate on pool size. Low reach dilutes your effective VP (fewer people in the demographic consider you), high reach lets you compete at full strength. A company with 0% reach gets 0 effective VP and 0 share. Total units across all companies never exceeds the pool.
 
 ### Step 4: Sales Noise
 
@@ -318,7 +319,7 @@ Three components, each serving a distinct role in the sales funnel.
 
 ### Brand Reach (per demographic, 0–100%)
 
-The percentage of a demographic that has heard of your company. Acts as a hard gate on your addressable market. If your reach among Students is 20%, you can only compete for 20% of the Student demand pool.
+The percentage of a demographic that has heard of your company. Acts as a multiplier on your competitive strength within the shared demand pool. If your reach among Students is 20%, your effective value proposition is scaled to 20% — most students don't know you exist, so your pull on the pool is weak. A company with 0% reach gets 0 effective VP and sells nothing.
 
 **Starting values:**
 - Player: 0% across all demographics. Must be bootstrapped through marketing.

--- a/src/renderer/screens/dashboard/AdvanceYearCard.tsx
+++ b/src/renderer/screens/dashboard/AdvanceYearCard.tsx
@@ -12,7 +12,8 @@ import { generateCompetitorModels } from "../../../simulation/competitorAI";
 import { simulateQuarter } from "../../../simulation/salesEngine";
 import { generateReviews, determineAwards } from "../../../simulation/reviewsAwards";
 import { QuarterSimulationResult, LaptopSalesResult } from "../../../simulation/salesTypes";
-import { QUARTER_LABELS } from "../../utils/formatCash";
+import { QUARTER_LABELS, formatCash } from "../../utils/formatCash";
+import { SPONSORSHIPS, getSponsorshipCost } from "../../../data/sponsorships";
 
 /** Models that need a current-year manufacturing plan before simulation. */
 function modelsNeedingPlans(state: { year: number; models: ReturnType<typeof getActiveModels> }) {
@@ -71,6 +72,13 @@ export function AdvanceYearCard() {
     );
   }
 
+  // Calculate brand marketing spend for display
+  const sponsorshipCost = state.sponsorships.reduce((sum, id) => {
+    const s = SPONSORSHIPS.find((sp) => sp.id === id);
+    return sum + (s ? getSponsorshipCost(s, state.year) : 0);
+  }, 0);
+  const brandSpend = state.brandAwarenessBudget + sponsorshipCost;
+
   return (
     <BentoCard title={`Simulate ${quarterLabel}`} icon={FastForward}>
       {warnings.length > 0 ? (
@@ -85,6 +93,14 @@ export function AdvanceYearCard() {
             ? `All models ready. Simulate ${quarterLabel} ${state.year}.`
             : `Simulate ${quarterLabel} ${state.year}. Adjust prices, order more units, or run new campaigns from Model Management.`
           }
+        </p>
+      )}
+      {brandSpend > 0 && (
+        <p style={{ ...cardBodyStyle, color: tokens.colors.textMuted }}>
+          Brand marketing: {formatCash(brandSpend)}
+          {state.brandAwarenessBudget > 0 && sponsorshipCost > 0
+            ? ` (${formatCash(state.brandAwarenessBudget)} awareness + ${formatCash(sponsorshipCost)} sponsorships)`
+            : ""}
         </p>
       )}
       <MenuButton

--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -331,7 +331,6 @@ function buildYearResult(
           if (match) {
             match.unitsDemanded += db.unitsDemanded;
             match.totalPool += db.totalPool;
-            match.addressablePool += db.addressablePool;
             match.marketShare = db.marketShare; // Use latest quarter's share
             match.rawVP = db.rawVP;
             match.weightedStatScore = db.weightedStatScore; // Use latest

--- a/src/simulation/salesEngine.ts
+++ b/src/simulation/salesEngine.ts
@@ -180,7 +180,7 @@ function getLaptopCampaignPerception(laptop: MarketLaptop, playerId: string): nu
  * Step 2 – Biased VP:
  *   biased_vp = raw_vp × (1 + brand_perception_mod / 100) × (1 + laptop_perception_mod / 100)
  *
- * Note: reach is NOT applied here — it gates the demand pool size instead (in simulateQuarter).
+ * Note: reach is NOT applied here — it multiplies effective VP in simulateQuarter.
  */
 interface VPComponents {
   biasedVP: number;
@@ -281,32 +281,32 @@ export function simulateQuarter(state: GameState): QuarterSimulationResult {
     // Quarterly active buyers = annual × quarter share
     const quarterlyActiveBuyers = annualActiveBuyers * quarterShare;
 
-    // Calculate biased VP for each laptop in this demographic
-    const vpEntries: { laptopId: string; vp: VPComponents; reachGatedPool: number }[] = [];
-    let totalBiasedVP = 0;
+    // Calculate effective VP for each laptop: biased_vp × (reach / 100)
+    // Reach multiplies competitive strength within one shared pool (no per-company pools)
+    const vpEntries: { laptopId: string; vp: VPComponents; effectiveVP: number }[] = [];
+    let totalEffectiveVP = 0;
 
     for (const laptop of allLaptops) {
       const normStats = normalisedStatsMap.get(laptop.id)!;
       const campPerc = campaignPerceptions.get(laptop.id)!;
       const vp = calculateBiasedVP(laptop, normStats, demographic, state, campPerc);
 
-      // Each laptop's addressable pool is gated by its owner's reach in this demographic
       const company = state.companies.find((c) => c.id === laptop.owner);
       let reach = company ? (company.brandReach[demId] ?? 0) : 0;
       if (company?.isPlayer) {
         reach += campaignReachBoost;
       }
       reach = Math.min(reach, 100);
-      const reachGatedPool = quarterlyActiveBuyers * (reach / 100);
+      const effectiveVP = vp.biasedVP * (reach / 100);
 
-      vpEntries.push({ laptopId: laptop.id, vp, reachGatedPool });
-      totalBiasedVP += vp.biasedVP;
+      vpEntries.push({ laptopId: laptop.id, vp, effectiveVP });
+      totalEffectiveVP += effectiveVP;
     }
 
-    // Everyone in the active pool buys: purchase_probability = biased_vp / sum(all biased_vps)
-    for (const { laptopId, vp, reachGatedPool } of vpEntries) {
-      const purchaseProbability = totalBiasedVP > 0 ? vp.biasedVP / totalBiasedVP : 0;
-      const unitsDemanded = Math.round(reachGatedPool * purchaseProbability);
+    // Everyone in the shared pool buys: purchase_probability = effective_vp / sum(all effective_vps)
+    for (const { laptopId, vp, effectiveVP } of vpEntries) {
+      const purchaseProbability = totalEffectiveVP > 0 ? effectiveVP / totalEffectiveVP : 0;
+      const unitsDemanded = Math.round(quarterlyActiveBuyers * purchaseProbability);
 
       const entry = demandByLaptop.get(laptopId)!;
       entry.total += unitsDemanded;
@@ -317,7 +317,6 @@ export function simulateQuarter(state: GameState): QuarterSimulationResult {
         unitsDemanded,
         rawVP: vp.rawVP,
         totalPool: Math.round(quarterlyActiveBuyers),
-        addressablePool: Math.round(reachGatedPool),
         weightedStatScore: vp.weightedStatScore,
         screenPenalty: vp.screenPenalty,
         perceptionMod: vp.perceptionMod,
@@ -493,20 +492,28 @@ export function projectDemandRange(
     const quarterShare = QUARTER_SHARES[state.quarter - 1] / QUARTER_SHARES_SUM;
     const quarterlyActiveBuyers = annualActiveBuyers * quarterShare;
 
-    let totalBiasedVP = 0;
-    let ourBiasedVP = 0;
+    let totalEffectiveVP = 0;
+    let ourEffectiveVP = 0;
 
     for (const laptop of allLaptops) {
       const normStats = normalisedStatsMap.get(laptop.id)!;
       const { biasedVP: vp } = calculateBiasedVP(laptop, normStats, demographic, state, 0);
-      totalBiasedVP += vp;
-      if (laptop.id === modelId) ourBiasedVP = vp;
+
+      // effective_vp = biased_vp × (reach / 100)
+      const company = state.companies.find((c) => c.id === laptop.owner);
+      let reach = company ? (company.brandReach[demId] ?? 0) : 0;
+      if (company?.isPlayer) {
+        reach += campaignReachBoost;
+      }
+      reach = Math.min(reach, 100);
+      const effectiveVP = vp * (reach / 100);
+
+      totalEffectiveVP += effectiveVP;
+      if (laptop.id === modelId) ourEffectiveVP = effectiveVP;
     }
 
-    const share = totalBiasedVP > 0 ? ourBiasedVP / totalBiasedVP : 0;
-    // Gate by player's reach in this demographic (including immediate campaign boost)
-    const reach = Math.min((player.brandReach[demId] ?? 0) + campaignReachBoost, 100);
-    totalExpected += quarterlyActiveBuyers * (reach / 100) * share;
+    const share = totalEffectiveVP > 0 ? ourEffectiveVP / totalEffectiveVP : 0;
+    totalExpected += quarterlyActiveBuyers * share;
   }
 
   const expected = Math.round(totalExpected);

--- a/src/simulation/salesTypes.ts
+++ b/src/simulation/salesTypes.ts
@@ -23,10 +23,8 @@ export interface DemographicSalesBreakdown {
   unitsDemanded: number;
   /** Raw value proposition (weighted_score × screen_penalty / price) before perception mods */
   rawVP: number;
-  /** Total demographic pool size this quarter (before reach gating) */
+  /** Total demographic pool size this quarter */
   totalPool: number;
-  /** Reach-gated addressable pool for this laptop */
-  addressablePool: number;
   /** Weighted stat score (dot product of normalised stats × demographic weights) */
   weightedStatScore: number;
   /** Screen size fit penalty (0.05–1.0) */


### PR DESCRIPTION
## Summary

- **Shared demand pool**: Replaced per-company reach-gated pools with a single shared pool. Reach now multiplies effective VP (`effective_vp = biased_vp × reach/100`) instead of gating pool size. Total units across all companies can never exceed the buyer pool.
- **Brand spend visibility**: AdvanceYearCard now shows awareness budget + sponsorship costs so the player sees total brand marketing outlay before simulating.
- **GDD updated**: Demand Resolution step and Brand Reach description updated to match new semantics.

Closes #76

## Test plan

- [ ] Start a new game, set awareness budget and sponsorships, verify costs shown on AdvanceYearCard
- [ ] Simulate Q1, check that total units sold across all companies ≤ quarterly pool size per demographic
- [ ] Verify 0% reach company sells 0 units
- [ ] Verify demand projections in manufacturing wizard are consistent with new formula