### PR TITLE
fix: remove placeholder data from dashboard cards

### DIFF
--- a/src/renderer/screens/dashboard/FinancialsCard.tsx
+++ b/src/renderer/screens/dashboard/FinancialsCard.tsx
@@ -1,39 +1,11 @@
 import { DollarSign } from "lucide-react";
-import { tokens } from "../../shell/tokens";
 import { BentoCard } from "./BentoCard";
-import { emptyStateStyle, sectionDividerStyle, sectionHeadingStyle, tableCellStyle } from "./styles";
+import { emptyStateStyle } from "./styles";
 
 export function FinancialsCard() {
   return (
     <BentoCard title="Financials" icon={DollarSign} screen="financialHistory">
-      <table style={{ width: "100%", borderCollapse: "collapse" }}>
-        <tbody>
-          {[
-            ["Revenue", "—"],
-            ["COGS", "—"],
-            ["Gross Profit", "—"],
-            ["Marketing", "—"],
-            ["R&D Overhead", "—"],
-            ["Net Profit", "—"],
-          ].map(([label, value]) => (
-            <tr key={label}>
-              <td style={tableCellStyle}>{label}</td>
-              <td style={{ ...tableCellStyle, textAlign: "right" }}>{value}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <div style={sectionDividerStyle}>
-        <p style={sectionHeadingStyle}>Cash Flow Trend</p>
-        <div style={{ display: "flex", gap: tokens.spacing.xs, marginTop: tokens.spacing.sm, height: 48, alignItems: "flex-end" }}>
-          {[0.3, 0.5, 0.4, 0.7, 0.6, 0.8, 0.65, 0.9].map((h, i) => (
-            <div key={i} style={{ flex: 1, height: `${h * 100}%`, background: tokens.colors.accent, borderRadius: 2, opacity: 0.5 }} />
-          ))}
-        </div>
-        <p style={{ ...emptyStateStyle, marginTop: tokens.spacing.sm }}>
-          Quarterly data available after Year 1
-        </p>
-      </div>
+      <p style={emptyStateStyle}>No financial data yet</p>
     </BentoCard>
   );
 }

--- a/src/renderer/screens/dashboard/HistoryCard.tsx
+++ b/src/renderer/screens/dashboard/HistoryCard.tsx
@@ -1,37 +1,11 @@
 import { History } from "lucide-react";
-import { tokens } from "../../shell/tokens";
 import { BentoCard } from "./BentoCard";
-import { cardBodyStyle, sectionDividerStyle, sectionHeadingStyle, tableCellStyle } from "./styles";
+import { emptyStateStyle } from "./styles";
 
 export function HistoryCard() {
   return (
     <BentoCard title="History" icon={History} screen="history">
-      <p style={sectionHeadingStyle}>Past Releases</p>
-      <p style={{ ...cardBodyStyle, marginTop: tokens.spacing.xs, fontStyle: "italic" }}>
-        No models released yet
-      </p>
-      <div style={sectionDividerStyle}>
-        <p style={sectionHeadingStyle}>Lifetime Stats</p>
-        <table style={{ width: "100%", borderCollapse: "collapse", marginTop: tokens.spacing.sm }}>
-          <tbody>
-            {[
-              ["Models designed", "0"],
-              ["Models launched", "0"],
-              ["Total units sold", "0"],
-              ["Total revenue", "$0"],
-              ["Total profit", "$0"],
-              ["Best seller", "—"],
-              ["Highest rated", "—"],
-              ["Awards won", "0"],
-            ].map(([label, value]) => (
-              <tr key={label}>
-                <td style={{ ...tableCellStyle, fontSize: tokens.font.sizeSmall }}>{label}</td>
-                <td style={{ ...tableCellStyle, fontSize: tokens.font.sizeSmall, textAlign: "right" }}>{value}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <p style={emptyStateStyle}>No history yet</p>
     </BentoCard>
   );
 }

--- a/src/renderer/screens/dashboard/MarketCard.tsx
+++ b/src/renderer/screens/dashboard/MarketCard.tsx
@@ -1,44 +1,11 @@
 import { BarChart3 } from "lucide-react";
-import { tokens } from "../../shell/tokens";
 import { BentoCard } from "./BentoCard";
-import { ProgressBar } from "./ProgressBar";
-import { cardBodyStyle, hintStyle, sectionDividerStyle, sectionHeadingStyle, smallTextStyle } from "./styles";
+import { emptyStateStyle } from "./styles";
 
 export function MarketCard() {
   return (
     <BentoCard title="Market" icon={BarChart3} screen="marketOverview">
-      <p style={cardBodyStyle}>Total Market Size: ~12M units/year</p>
-      <p style={{ ...sectionHeadingStyle, marginTop: tokens.spacing.md }}>
-        Top Competitors
-      </p>
-      {[
-        { name: "BudgetTech", models: 3, avg: "$599", strategy: "High volume, low margin" },
-        { name: "LuxBook", models: 2, avg: "$1,899", strategy: "Premium materials, brand cachet" },
-        { name: "OmniLap", models: 4, avg: "$999", strategy: "Broad range, generalist" },
-      ].map((c) => (
-        <div key={c.name} style={{ marginTop: tokens.spacing.sm, paddingLeft: tokens.spacing.sm, borderLeft: `2px solid ${tokens.colors.panelBorder}` }}>
-          <p style={sectionHeadingStyle}>{c.name}</p>
-          <p style={cardBodyStyle}>{c.models} models — avg {c.avg}</p>
-          <p style={hintStyle}>{c.strategy}</p>
-        </div>
-      ))}
-      <div style={sectionDividerStyle}>
-        <p style={sectionHeadingStyle}>Demographic Split</p>
-        {[
-          { name: "Corporate", pct: 22 },
-          { name: "Consumer", pct: 28 },
-          { name: "Student", pct: 18 },
-          { name: "Creative", pct: 12 },
-          { name: "Gamer", pct: 10 },
-          { name: "Other", pct: 10 },
-        ].map((d) => (
-          <div key={d.name} style={{ display: "flex", alignItems: "center", gap: tokens.spacing.sm, marginTop: tokens.spacing.xs }}>
-            <span style={{ ...smallTextStyle, width: 70 }}>{d.name}</span>
-            <ProgressBar value={d.pct} />
-            <span style={{ ...smallTextStyle, width: 30, textAlign: "right" }}>{d.pct}%</span>
-          </div>
-        ))}
-      </div>
+      <p style={emptyStateStyle}>No market data yet</p>
     </BentoCard>
   );
 }

--- a/src/renderer/screens/dashboard/NewsCard.tsx
+++ b/src/renderer/screens/dashboard/NewsCard.tsx
@@ -1,25 +1,11 @@
 import { Newspaper } from "lucide-react";
-import { tokens } from "../../shell/tokens";
 import { BentoCard } from "./BentoCard";
-import { cardBodyStyle, smallTextStyle } from "./styles";
+import { emptyStateStyle } from "./styles";
 
 export function NewsCard() {
   return (
     <BentoCard title="News" icon={Newspaper} screen="news">
-      {[
-        { date: "Jan 2000", text: "The laptop market enters a new decade with growing consumer demand across all segments." },
-        { date: "Jan 2000", text: "BudgetTech announces aggressive pricing strategy, aiming to capture the student and budget buyer markets." },
-        { date: "Jan 2000", text: "Industry analysts predict 15% year-on-year growth in the consumer laptop segment through 2002." },
-        { date: "Jan 2000", text: "LuxBook unveils premium aluminium unibody chassis — sets new standard for build quality." },
-        { date: "Jan 2000", text: "Corporate IT spending surges as Y2K upgrades drive bulk laptop purchases worldwide." },
-        { date: "Jan 2000", text: "OmniLap expands product line with 4 new models targeting every price bracket." },
-        { date: "Jan 2000", text: "Display technology advances push screen resolutions higher — 1024×768 becomes the new baseline." },
-      ].map((item, i, arr) => (
-        <div key={i} style={{ marginTop: i === 0 ? 0 : tokens.spacing.sm, paddingBottom: tokens.spacing.sm, borderBottom: i < arr.length - 1 ? `1px solid ${tokens.colors.panelBorder}` : "none" }}>
-          <p style={{ ...smallTextStyle, color: tokens.colors.accent }}>{item.date}</p>
-          <p style={cardBodyStyle}>{item.text}</p>
-        </div>
-      ))}
+      <p style={emptyStateStyle}>No news yet</p>
     </BentoCard>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced hardcoded placeholder content in NewsCard, FinancialsCard, MarketCard, and HistoryCard with simple empty-state messages
- Cards now show "No [x] yet" instead of misleading fake data
- Cards will be wired up to real game state in a future PR

Closes #86

## Test plan
- [ ] Verify all 4 cards show empty-state text instead of placeholder data
- [ ] Verify unaffected cards (ModelsCard, BrandCard, AdvanceYearCard, ReviewsCard) still work