### PR TITLE
feat: year-dependent minimum bezel width

### DIFF
--- a/src/data/designConstants.ts
+++ b/src/data/designConstants.ts
@@ -29,10 +29,26 @@ export const THICKNESS_DEFAULT_CM = 3.5;
 
 // --- Bezel ---
 
+/** Absolute minimum bezel ever achievable (modern era) */
 export const BEZEL_MIN_MM = 3;
 export const BEZEL_MAX_MM = 40;
 export const BEZEL_STEP_MM = 1;
 export const BEZEL_DEFAULT_MM = 20;
+
+/**
+ * Year-dependent minimum bezel width (mm).
+ * Reflects manufacturing & display technology constraints:
+ *   2000: ~10mm (thick LCD bezels, bulky inverters)
+ *   2010: ~6mm  (LED backlights, thinner panels)
+ *   2020+: ~3mm (near borderless, OLED flex cables)
+ * Smooth exponential decay from 10 → 3 over 20 years.
+ */
+export function minBezelForYear(year: number): number {
+  const t = Math.max(0, Math.min(1, (year - 2000) / 20));
+  // Exponential decay: 10mm → 3mm
+  const min = BEZEL_MIN_MM + (10 - BEZEL_MIN_MM) * Math.pow(1 - t, 2);
+  return Math.round(min);
+}
 
 // --- Design bonus tuning constants ---
 

--- a/src/renderer/wizard/optimiser.ts
+++ b/src/renderer/wizard/optimiser.ts
@@ -23,7 +23,7 @@ import {
   THICKNESS_MIN_CM,
   THICKNESS_MAX_CM,
   THICKNESS_STEP_CM,
-  BEZEL_MIN_MM,
+  minBezelForYear,
   MIN_BATTERY_WH,
   MAX_BATTERY_WH,
   BATTERY_STEP_WH,
@@ -86,7 +86,7 @@ function findMinThickness(
   const minHeight = maxHeightConstraintCm(components, {}, chassisOptions);
 
   for (let t = THICKNESS_MIN_CM; t <= THICKNESS_MAX_CM; t = Math.round((t + THICKNESS_STEP_CM) * 10) / 10) {
-    const avail = availableVolumeCm3(screenSize, BEZEL_MIN_MM, t, year);
+    const avail = availableVolumeCm3(screenSize, minBezelForYear(year), t, year);
     if (avail >= consumedVol && t >= minHeight) {
       return t;
     }
@@ -114,7 +114,7 @@ function scoreBuild(
     chassis,
     batteryCapacityWh,
     thicknessCm: thickness,
-    bezelMm: BEZEL_MIN_MM,
+    bezelMm: minBezelForYear(year),
     selectedColours,
     gameYear: year,
   });
@@ -329,7 +329,7 @@ export function optimiseForDemographic(demographic: Demographic, year: number): 
         chassis: optimised.chassis,
         batteryCapacityWh: optimised.batteryCapacityWh,
         thicknessCm: thickness,
-        bezelMm: BEZEL_MIN_MM,
+        bezelMm: minBezelForYear(year),
         selectedColours,
       };
     }
@@ -343,7 +343,7 @@ export function optimiseForDemographic(demographic: Demographic, year: number): 
       chassis: { material: null, coolingSolution: null, keyboardFeature: null, trackpadFeature: null },
       batteryCapacityWh: MIN_BATTERY_WH,
       thicknessCm: THICKNESS_MAX_CM,
-      bezelMm: BEZEL_MIN_MM,
+      bezelMm: minBezelForYear(year),
       selectedColours: [COLOUR_OPTIONS[0].id],
     };
   }

--- a/src/renderer/wizard/steps/BodyStep.tsx
+++ b/src/renderer/wizard/steps/BodyStep.tsx
@@ -3,9 +3,9 @@ import {
   THICKNESS_MIN_CM,
   THICKNESS_MAX_CM,
   THICKNESS_STEP_CM,
-  BEZEL_MIN_MM,
   BEZEL_MAX_MM,
   BEZEL_STEP_MM,
+  minBezelForYear,
   availableVolumeCm3,
   minThicknessForVolumeCm,
   chassisCost,
@@ -28,6 +28,7 @@ export function BodyStep() {
   const { state, dispatch, gameYear } = useWizard();
 
   const thickness = state.thicknessCm;
+  const bezelMin = minBezelForYear(gameYear);
   const bezel = state.bezelMm;
 
   // --- Volume ---
@@ -106,7 +107,7 @@ export function BodyStep() {
               Bezel Width (uniform)
             </div>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "4px" }}>
-              <span style={{ color: "#888", fontSize: "0.75rem" }}>{BEZEL_MIN_MM} mm</span>
+              <span style={{ color: "#888", fontSize: "0.75rem" }}>{bezelMin} mm</span>
               <span style={{ fontSize: "1.75rem", fontWeight: "bold", color: tokens.colors.interactiveAccent }}>
                 {bezel} mm
               </span>
@@ -114,7 +115,7 @@ export function BodyStep() {
             </div>
             <input
               type="range"
-              min={BEZEL_MIN_MM}
+              min={bezelMin}
               max={BEZEL_MAX_MM}
               step={BEZEL_STEP_MM}
               value={bezel}

--- a/src/renderer/wizard/steps/ReviewEditDialog.tsx
+++ b/src/renderer/wizard/steps/ReviewEditDialog.tsx
@@ -15,9 +15,9 @@ import {
   THICKNESS_MIN_CM,
   THICKNESS_MAX_CM,
   THICKNESS_STEP_CM,
-  BEZEL_MIN_MM,
   BEZEL_MAX_MM,
   BEZEL_STEP_MM,
+  minBezelForYear,
   minThicknessForVolumeCm,
   getAvailableComponents,
   getAvailableChassisOptions,
@@ -433,19 +433,20 @@ function ThicknessEditor() {
 }
 
 function BezelEditor() {
-  const { state, dispatch } = useWizard();
+  const { state, dispatch, gameYear } = useWizard();
   const bezel = state.bezelMm;
+  const bezelMin = minBezelForYear(gameYear);
 
   return (
     <div>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "12px" }}>
-        <span style={{ color: "#888", fontSize: "0.875rem" }}>{BEZEL_MIN_MM} mm</span>
+        <span style={{ color: "#888", fontSize: "0.875rem" }}>{bezelMin} mm</span>
         <span style={{ fontSize: "2.5rem", fontWeight: "bold", color: tokens.colors.interactiveAccent }}>{bezel} mm</span>
         <span style={{ color: "#888", fontSize: "0.875rem" }}>{BEZEL_MAX_MM} mm</span>
       </div>
       <input
         type="range"
-        min={BEZEL_MIN_MM}
+        min={bezelMin}
         max={BEZEL_MAX_MM}
         step={BEZEL_STEP_MM}
         value={bezel}

--- a/src/simulation/competitorAI.ts
+++ b/src/simulation/competitorAI.ts
@@ -13,8 +13,8 @@ import {
   THICKNESS_MIN_CM,
   THICKNESS_MAX_CM,
   THICKNESS_STEP_CM,
-  BEZEL_MIN_MM,
   BEZEL_MAX_MM,
+  minBezelForYear,
 } from "../data/designConstants";
 import {
   MATERIALS,
@@ -215,10 +215,11 @@ function pickThickness(archetype: CompetitorArchetype): number {
   return Math.round((2.5 + Math.random() * 1.5) / THICKNESS_STEP_CM) * THICKNESS_STEP_CM;
 }
 
-function pickBezel(archetype: CompetitorArchetype): number {
+function pickBezel(archetype: CompetitorArchetype, year: number): number {
+  const minBezel = minBezelForYear(year);
   if (archetype === "budget") return BEZEL_MAX_MM - Math.floor(Math.random() * 5); // 35-40mm
-  if (archetype === "premium") return BEZEL_MIN_MM + Math.floor(Math.random() * 5); // 3-7mm
-  return 15 + Math.floor(Math.random() * 10); // 15-24mm
+  if (archetype === "premium") return minBezel + Math.floor(Math.random() * 5);
+  return Math.max(minBezel, 15) + Math.floor(Math.random() * 10);
 }
 
 function generateSingleModel(
@@ -256,7 +257,7 @@ function generateSingleModel(
   };
 
   const thicknessCm = clamp(pickThickness(archetype), THICKNESS_MIN_CM, THICKNESS_MAX_CM);
-  const bezelMm = clamp(pickBezel(archetype), BEZEL_MIN_MM, BEZEL_MAX_MM);
+  const bezelMm = clamp(pickBezel(archetype, year), minBezelForYear(year), BEZEL_MAX_MM);
   const batteryCapacityWh = pickBattery(archetype);
   const ports = pickPorts(year, archetype);
   const selectedColours = pickColours(archetype);

--- a/src/simulation/theoreticalMax.ts
+++ b/src/simulation/theoreticalMax.ts
@@ -28,8 +28,8 @@ import {
   THICKNESS_MIN_CM,
   THICKNESS_MAX_CM,
   THICKNESS_STEP_CM,
-  BEZEL_MIN_MM,
   BEZEL_MAX_MM,
+  minBezelForYear,
   availableVolumeCm3,
   totalConsumedVolumeCm3,
   maxHeightConstraintCm,
@@ -198,9 +198,10 @@ function computeTheoreticalMaxForStat(targetStat: LaptopStat, year: number): num
     const selectedColours = targetStat === "design" ? ALL_COLOUR_IDS : [COLOUR_OPTIONS[0].id];
 
     // Bezel
-    const bezelMm = targetStat === "design" ? BEZEL_MIN_MM
+    const minBezel = minBezelForYear(year);
+    const bezelMm = targetStat === "design" ? minBezel
       : (targetStat === "performance" || targetStat === "gamingPerformance") ? BEZEL_MAX_MM
-      : BEZEL_MIN_MM;
+      : minBezel;
 
     // Battery: initial guess (only batteryLife wants max; everything else starts minimal)
     const initBattery = targetStat === "batteryLife" ? MAX_BATTERY_WH : MIN_BATTERY_WH;


### PR DESCRIPTION
## Summary

- Adds `minBezelForYear(year)` function with smooth quadratic decay: ~10mm in 2000 → ~3mm by 2020+
- Updates design wizard sliders (BodyStep + ReviewEditDialog) to enforce the year-dependent minimum
- Updates competitor AI to respect the minimum for its era
- Updates optimiser and theoretical max calculations to use year-dependent minimum

Closes #99