### PR TITLE
feat: AI head start — pre-simulate year 2000 before player starts

### DIFF
--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -3,9 +3,11 @@ import { DemographicId } from "../../data/types";
 import { GameState, Quarter, LaptopDesign, LaptopModel, ModelStatus, CompanyState, createInitialGameState, hasDiscontinuedComponents } from "./gameTypes";
 import { FullManufacturingPlan } from "../manufacturing/types";
 import { QuarterSimulationResult } from "../../simulation/salesTypes";
-import { clearProjectionCache } from "../../simulation/salesEngine";
+import { clearProjectionCache, simulateQuarter } from "../../simulation/salesEngine";
 import { updateBrandReach, updateCompetitorBrandReach, applySingleQuarterPerception } from "../../simulation/brandProgression";
 import { applyDeathSpiralPrevention } from "../../simulation/deathSpiralPrevention";
+import { generateCompetitorModels } from "../../simulation/competitorAI";
+import { COMPETITORS } from "../../data/competitors";
 import { LaptopReview, Award, applyAwardBonuses } from "../../simulation/reviewsAwards";
 import { SPONSORSHIPS, getSponsorshipCost } from "../../data/sponsorships";
 import { PERCEPTION_MEANINGFUL_DELTA } from "../../simulation/tunables";
@@ -57,11 +59,60 @@ function updatePlayerModels(
   return updatePlayer(companies, (p) => ({ ...p, models: modelUpdater(p.models) }));
 }
 
+/**
+ * Pre-simulate one full year of AI-only play.
+ * Generates competitor models, runs 4 quarters of simulation, updates brand
+ * reach/perception, then advances the year — so the player starts with an
+ * established market.
+ */
+function preSimulateAIYear(initial: GameState): GameState {
+  let s = initial;
+
+  // Generate AI models for this year
+  const generated = generateCompetitorModels(s.year, COMPETITORS, s.companies);
+  const modelByCompetitor = new Map(COMPETITORS.map((c, i) => [c.id, generated[i]]));
+  s = {
+    ...s,
+    companies: s.companies.map((comp) => {
+      if (comp.isPlayer) return comp;
+      const model = modelByCompetitor.get(comp.id);
+      return model ? { ...comp, models: [...comp.models, model] } : comp;
+    }),
+  };
+
+  // Simulate all 4 quarters
+  for (let q = 1; q <= 4; q++) {
+    s = { ...s, quarter: q as Quarter };
+    const result = simulateQuarter(s);
+
+    // Update competitor brand reach & perception (same as APPLY_QUARTER_RESULT)
+    s = {
+      ...s,
+      companies: s.companies.map((comp) => {
+        if (comp.isPlayer) return comp;
+        return {
+          ...comp,
+          brandReach: updateCompetitorBrandReach(comp, result),
+          brandPerception: applySingleQuarterPerception(comp, result.laptopResults),
+        };
+      }),
+    };
+  }
+
+  // Advance to next year Q1
+  return {
+    ...s,
+    year: s.year + 1,
+    quarter: 1 as Quarter,
+    quarterSimulated: false,
+  };
+}
+
 function gameReducer(state: GameState, action: GameAction): GameState {
   switch (action.type) {
     case "NEW_GAME":
       clearProjectionCache();
-      return createInitialGameState(action.companyName, action.companyLogo);
+      return preSimulateAIYear(createInitialGameState(action.companyName, action.companyLogo));
     case "LOAD_GAME":
       clearProjectionCache();
       return action.state;

--- a/src/renderer/state/gameTypes.ts
+++ b/src/renderer/state/gameTypes.ts
@@ -99,7 +99,8 @@ export function modelDisplayName(companyName: string, designName: string): strin
 }
 
 export const STARTING_CASH = 50_000_000;
-export const STARTING_YEAR = 2000;
+export const AI_STARTING_YEAR = 2000;
+export const STARTING_YEAR = AI_STARTING_YEAR + 1;
 
 const ZERO_DEMOGRAPHICS: Record<DemographicId, number> = {
   corporate: 0,
@@ -139,7 +140,7 @@ export function createInitialGameState(
   return {
     companies: [playerCompany, ...aiCompanies],
     companyLogo,
-    year: STARTING_YEAR,
+    year: AI_STARTING_YEAR,
     quarter: 1 as Quarter,
     quarterSimulated: false,
     cash: STARTING_CASH,


### PR DESCRIPTION
## Summary
- Player now starts in **2001 Q1** instead of 2000 Q1
- AI competitors play through year 2000 automatically at game init (4 quarters of simulation)
- When the player opens a new game, AI companies already have laptop models on the market and updated brand reach/perception from their year-2000 sales

## Changes
- Added `AI_STARTING_YEAR = 2000` constant, `STARTING_YEAR` now derives from it (`AI_STARTING_YEAR + 1`)
- `createInitialGameState` initialises at year 2000, then `preSimulateAIYear()` runs 4 quarters of AI-only simulation before the player sees anything
- No changes to gameplay mechanics — same simulation, just run once before the player starts

## Test plan
- [ ] Start a new game — verify it says "Starting Year: 2001"
- [ ] On the dashboard, check the market browser — AI laptops from year 2000 should be visible
- [ ] Verify competitor brand reach/perception values are non-zero (updated from year-2000 sales)
- [ ] Simulate Q1 2001 — competitors should get new 2001 models as usual