### PR TITLE
fix: rename duplicate Market card to Competitors

### DIFF
--- a/src/renderer/screens/dashboard/CompetitorsCard.tsx
+++ b/src/renderer/screens/dashboard/CompetitorsCard.tsx
@@ -101,7 +101,7 @@ export function CompetitorsCard() {
   }
 
   return (
-    <BentoCard title="Market" icon={Monitor} screen="marketBrowser">
+    <BentoCard title="Competitors" icon={Monitor} screen="marketBrowser">
       <div style={{ display: "flex", flexDirection: "column", gap: tokens.spacing.md }}>
         {/* Model counts */}
         <div style={{ fontSize: tokens.font.sizeSmall, color: tokens.colors.textMuted }}>


### PR DESCRIPTION
## Summary
- Renames `CompetitorsCard` title from "Market" to "Competitors" so it's distinguishable from `MarketCard` on the dashboard

Closes #124

## Test plan
- [ ] Open dashboard and verify the two cards now have distinct titles ("Competitors" and "Market")