### PR TITLE
feat: add demographic hints to design wizard sidebar

### DIFF
--- a/src/renderer/wizard/DemographicHints.tsx
+++ b/src/renderer/wizard/DemographicHints.tsx
@@ -4,6 +4,7 @@ import { DEMOGRAPHICS } from "../../data/demographics";
 import { DemographicId, STAT_LABELS } from "../../data/types";
 import { CustomSelect, SelectOption } from "../shell/CustomSelect";
 import { Tooltip } from "./Tooltip";
+import { SidebarDivider } from "./LaptopEstimateSidebar";
 
 const DEMOGRAPHIC_OPTIONS: SelectOption<DemographicId>[] = DEMOGRAPHICS
   .map((d) => ({ value: d.id, label: d.name }))
@@ -31,6 +32,32 @@ function getTopAndBottom(demId: DemographicId): { top: RankedStat[]; bottom: Ran
   };
 }
 
+function StatRankList({ title, color, stats }: { title: string; color: string; stats: RankedStat[] }) {
+  return (
+    <div style={{ marginBottom: "6px" }}>
+      <div style={{ color, fontSize: "0.6875rem", fontWeight: "bold", marginBottom: "4px" }}>
+        {title}
+      </div>
+      {stats.map((s) => (
+        <div
+          key={s.label}
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            fontSize: "0.75rem",
+            color: "#e0e0e0",
+            marginBottom: "2px",
+            paddingLeft: "4px",
+          }}
+        >
+          <span>{s.label}</span>
+          <span style={{ color: "#888" }}>{Math.round(s.weight * 100)}%</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function DemographicHints() {
   const [selectedDem, setSelectedDem] = useState<DemographicId>(DEMOGRAPHIC_OPTIONS[0].value);
   const [collapsed, setCollapsed] = useState(false);
@@ -39,7 +66,7 @@ export function DemographicHints() {
 
   return (
     <>
-      <div style={{ borderTop: "1px solid #333", margin: "12px 0" }} />
+      <SidebarDivider />
       <div
         style={{
           display: "flex",
@@ -83,49 +110,8 @@ export function DemographicHints() {
             />
           </div>
 
-          <div style={{ marginBottom: "6px" }}>
-            <div style={{ color: "#66bb6a", fontSize: "0.6875rem", fontWeight: "bold", marginBottom: "4px" }}>
-              Prioritises
-            </div>
-            {top.map((s) => (
-              <div
-                key={s.label}
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  fontSize: "0.75rem",
-                  color: "#e0e0e0",
-                  marginBottom: "2px",
-                  paddingLeft: "4px",
-                }}
-              >
-                <span>{s.label}</span>
-                <span style={{ color: "#888" }}>{Math.round(s.weight * 100)}%</span>
-              </div>
-            ))}
-          </div>
-
-          <div>
-            <div style={{ color: "#ef5350", fontSize: "0.6875rem", fontWeight: "bold", marginBottom: "4px" }}>
-              Ignores
-            </div>
-            {bottom.map((s) => (
-              <div
-                key={s.label}
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  fontSize: "0.75rem",
-                  color: "#e0e0e0",
-                  marginBottom: "2px",
-                  paddingLeft: "4px",
-                }}
-              >
-                <span>{s.label}</span>
-                <span style={{ color: "#888" }}>{Math.round(s.weight * 100)}%</span>
-              </div>
-            ))}
-          </div>
+          <StatRankList title="Prioritises" color="#66bb6a" stats={top} />
+          <StatRankList title="Ignores" color="#ef5350" stats={bottom} />
         </>
       )}
     </>

--- a/src/renderer/wizard/LaptopEstimateSidebar.tsx
+++ b/src/renderer/wizard/LaptopEstimateSidebar.tsx
@@ -196,7 +196,7 @@ export function WizardSidebar({
   );
 }
 
-function SidebarHeading({ children }: { children: string }) {
+export function SidebarHeading({ children }: { children: string }) {
   return (
     <div style={{ color: "#888", fontSize: "0.6875rem", marginBottom: "10px", fontWeight: "bold", letterSpacing: "0.5px" }}>
       {children}
@@ -204,7 +204,7 @@ function SidebarHeading({ children }: { children: string }) {
   );
 }
 
-function SidebarDivider() {
+export function SidebarDivider() {
   return <div style={{ borderTop: "1px solid #333", margin: "12px 0" }} />;
 }
 


### PR DESCRIPTION
## Summary
- Adds a collapsible "Demographic Hints" section to the design wizard sidebar showing top 3 prioritised and bottom 3 ignored stats for a selected demographic
- Uses `CustomSelect` dropdown to pick which demographic to view — persists across wizard steps
- Includes price weight in the ranking so price-dominant demographics (Budget Buyer, Student) show accurate priorities
- Info tooltip on the section header explains the feature to new players

Closes #122

## Test plan
- [ ] Open design wizard, verify "Demographic Hints" section appears below Statistics
- [ ] Expand/collapse the section
- [ ] Switch between demographics and verify top 3 / bottom 3 stats are correct
- [ ] Hover the info icon and verify tooltip appears
- [ ] Check sidebar doesn't overflow when laptop estimate is also visible
- [ ] Verify CustomSelect dropdown renders correctly (not native select)