### PR TITLE
fix: deduplicate SidebarHeading component

### DIFF
--- a/src/renderer/screens/BrandDetailScreen.tsx
+++ b/src/renderer/screens/BrandDetailScreen.tsx
@@ -13,6 +13,7 @@ import { DEMOGRAPHICS } from "../../data/demographics";
 import { SPONSORSHIPS, getSponsorshipCost } from "../../data/sponsorships";
 import { DemographicId } from "../../data/types";
 import { PerceptionChange } from "../../simulation/salesTypes";
+import { SidebarHeading } from "../wizard/LaptopEstimateSidebar";
 import { PERCEPTION_MEANINGFUL_DELTA } from "../../simulation/tunables";
 
 const BUDGET_PRESETS = [0, 100_000, 250_000, 500_000, 1_000_000, 2_000_000];
@@ -271,10 +272,3 @@ export function BrandDetailScreen() {
   );
 }
 
-function SidebarHeading({ children }: { children: string }) {
-  return (
-    <div style={{ color: tokens.colors.textMuted, fontSize: "0.6875rem", marginBottom: 10, fontWeight: "bold", letterSpacing: "0.5px" }}>
-      {children}
-    </div>
-  );
-}

--- a/src/renderer/wizard/LaptopEstimateSidebar.tsx
+++ b/src/renderer/wizard/LaptopEstimateSidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { tokens } from "../shell/tokens";
 import { useWizard } from "./WizardContext";
 import { LaptopStat, StatVector } from "../../data/types";
 import {
@@ -198,7 +199,7 @@ export function WizardSidebar({
 
 export function SidebarHeading({ children }: { children: string }) {
   return (
-    <div style={{ color: "#888", fontSize: "0.6875rem", marginBottom: "10px", fontWeight: "bold", letterSpacing: "0.5px" }}>
+    <div style={{ color: tokens.colors.textMuted, fontSize: "0.6875rem", marginBottom: 10, fontWeight: "bold", letterSpacing: "0.5px" }}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove local `SidebarHeading` from `BrandDetailScreen.tsx` and import the shared one from `LaptopEstimateSidebar.tsx`
- Unify color from hard-coded `"#888"` to `tokens.colors.textMuted`

Closes #133

## Test plan
- [ ] Verify LaptopEstimateSidebar headings render correctly in the design wizard
- [ ] Verify BrandDetailScreen headings render correctly