### PR TITLE
fix: track AI inventory properly across quarters

### DIFF
--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -87,7 +87,10 @@ function preSimulateAIYear(initial: GameState): GameState {
     s = { ...s, quarter: q as Quarter };
     const result = simulateQuarter(s);
 
-    // Update competitor brand reach & perception (same as APPLY_QUARTER_RESULT)
+    // Update competitor brand reach, perception, and inventory (same as APPLY_QUARTER_RESULT)
+    const simByLaptop = new Map(
+      result.laptopResults.map((r) => [r.laptopId, r]),
+    );
     s = {
       ...s,
       companies: s.companies.map((comp) => {
@@ -96,6 +99,11 @@ function preSimulateAIYear(initial: GameState): GameState {
           ...comp,
           brandReach: updateCompetitorBrandReach(comp, result),
           brandPerception: applySingleQuarterPerception(comp, result.laptopResults),
+          models: comp.models.map((m) => {
+            const sim = simByLaptop.get(m.design.id);
+            if (!sim) return m;
+            return { ...m, unitsInStock: sim.unsoldUnits };
+          }),
         };
       }),
     };
@@ -301,6 +309,10 @@ function gameReducer(state: GameState, action: GameAction): GameState {
       const simByLaptop = new Map(
         result.playerResults.map((r) => [r.laptopId, r]),
       );
+      // Build lookup for all laptops (including AI) to update inventory
+      const allSimByLaptop = new Map(
+        result.laptopResults.map((r) => [r.laptopId, r]),
+      );
 
       const newPlayerReach = updateBrandReach(state, result);
       const newPlayerPerception = Object.fromEntries(
@@ -339,11 +351,16 @@ function gameReducer(state: GameState, action: GameAction): GameState {
             }),
           };
         }
-        // Competitor: update brand reach & perception
+        // Competitor: update brand reach, perception, and inventory
         return {
           ...comp,
           brandReach: updateCompetitorBrandReach(comp, result),
           brandPerception: applySingleQuarterPerception(comp, result.laptopResults),
+          models: comp.models.map((m) => {
+            const sim = allSimByLaptop.get(m.design.id);
+            if (!sim) return m;
+            return { ...m, unitsInStock: sim.unsoldUnits };
+          }),
         };
       });
 

--- a/src/simulation/competitorAI.ts
+++ b/src/simulation/competitorAI.ts
@@ -301,7 +301,7 @@ function generateSingleModel(
     manufacturingQuantity,
     yearDesigned: year,
     manufacturingPlan: null,
-    unitsInStock: 0,
+    unitsInStock: manufacturingQuantity,
     totalProductionSpend: 0,
     totalUnitsOrdered: 0,
   };

--- a/src/simulation/salesEngine.ts
+++ b/src/simulation/salesEngine.ts
@@ -103,7 +103,7 @@ function buildMarketLaptops(state: GameState): MarketLaptop[] {
     if (comp.isPlayer) continue;
     for (const model of comp.models) {
       if (model.yearDesigned !== state.year) continue;
-      if (!model.retailPrice || !model.manufacturingQuantity) continue;
+      if (!model.retailPrice || model.unitsInStock <= 0) continue;
 
       const stats = computeStatsForDesign(model.design, state.year);
 
@@ -113,8 +113,8 @@ function buildMarketLaptops(state: GameState): MarketLaptop[] {
         model,
         stats,
         retailPrice: model.retailPrice,
-        manufacturingQuantity: model.manufacturingQuantity,
-        totalManufacturingCost: model.manufacturingQuantity * model.design.unitCost,
+        manufacturingQuantity: model.unitsInStock,
+        totalManufacturingCost: model.unitsInStock * model.design.unitCost,
       });
     }
   }


### PR DESCRIPTION
## Summary

Fixes AI competitors having infinite effective inventory. Their `manufacturingQuantity` was used as a per-quarter sales cap but never decremented, allowing them to sell their full stock every quarter.

- Set `unitsInStock = manufacturingQuantity` when AI models are created (was `0`)
- Use `unitsInStock` instead of `manufacturingQuantity` as available quantity in `buildMarketLaptops`
- Decrement AI `unitsInStock` after each quarter in `APPLY_QUARTER_RESULT` (mirrors player logic)
- Same fix in `preSimulateAIYear` so the pre-game year also tracks inventory correctly

## Test plan

- [ ] Start a new game — AI competitors should sell out or have reduced stock across Q2–Q4
- [ ] Check that AI models with 0 remaining stock don't appear in the market
- [ ] Verify player inventory behavior is unchanged

Part of #137 (PR 1 of 6)