### PR TITLE
fix: compute AI retail price from fully loaded cost

### DIFF
--- a/src/data/competitors.ts
+++ b/src/data/competitors.ts
@@ -54,7 +54,7 @@ export const COMPETITORS: CompetitorDefinition[] = [
       high: [],
       low: ["buildQuality", "design", "display"],
     },
-    pricingStrategy: { marginMultiplier: 1.05 },
+    pricingStrategy: { marginMultiplier: 1.15 },
     screenSizePreference: [14, 15],
     chassisPreferences: {
       materialTier: "low",
@@ -91,7 +91,7 @@ export const COMPETITORS: CompetitorDefinition[] = [
       high: ["design", "display", "buildQuality", "keyboard"],
       low: [],
     },
-    pricingStrategy: { marginMultiplier: 1.15 },
+    pricingStrategy: { marginMultiplier: 1.40 },
     screenSizePreference: [13, 14, 15],
     chassisPreferences: {
       materialTier: "high",
@@ -128,7 +128,7 @@ export const COMPETITORS: CompetitorDefinition[] = [
       high: [],
       low: [],
     },
-    pricingStrategy: { marginMultiplier: 1.0 },
+    pricingStrategy: { marginMultiplier: 1.25 },
     screenSizePreference: [14, 15, 16],
     chassisPreferences: {
       materialTier: "mid",

--- a/src/simulation/competitorAI.ts
+++ b/src/simulation/competitorAI.ts
@@ -26,6 +26,15 @@ import { PORT_TYPES } from "../data/portTypes";
 import { COLOUR_OPTIONS } from "../data/colourOptions";
 import { STARTING_DEMAND_POOL } from "../data/startingDemand";
 import { averageReach } from "./brandProgression";
+import { calculateBomUnitCost } from "../renderer/manufacturing/utils/economiesOfScale";
+import {
+  ASSEMBLY_QA_COST,
+  PACKAGING_LOGISTICS_COST,
+  CHANNEL_MARGIN_RATE,
+  RD_COST,
+  TOOLING_COST,
+  CERTIFICATION_COST,
+} from "./tunables";
 
 const COMPONENT_SLOTS: ComponentSlot[] = [
   "cpu", "gpu", "ram", "storage",
@@ -286,13 +295,24 @@ function generateSingleModel(
     unitCost: totals.totalCost,
   };
 
-  const retailPrice = Math.round(totals.totalCost * competitor.pricingStrategy.marginMultiplier);
-
   // Manufacturing quantity heuristic: base pool size scaled by average brand reach
   const totalDemand = Object.values(STARTING_DEMAND_POOL).reduce((sum, v) => sum + v, 0);
   const brandFactor = averageReach(competitor.brandReach) / 100;
   const competitorShare = 1 / totalPlayerCount;
   const manufacturingQuantity = Math.round(totalDemand * competitorShare * brandFactor * (0.8 + Math.random() * 0.4));
+
+  // Fully loaded cost: BOM after EoS + assembly + packaging + amortised fixed costs
+  const bomAfterEos = calculateBomUnitCost(totals.totalCost, manufacturingQuantity);
+  const variableCost = bomAfterEos + ASSEMBLY_QA_COST + PACKAGING_LOGISTICS_COST;
+  const modelType = design.modelType;
+  const fixedCosts = RD_COST[modelType] + TOOLING_COST[modelType] + CERTIFICATION_COST[modelType];
+  const amortizedFixed = fixedCosts / manufacturingQuantity;
+  const fullyLoadedCost = variableCost + amortizedFixed;
+
+  // Price covers all costs after retailer takes their 20% cut, times margin
+  const retailPrice = Math.round(
+    (fullyLoadedCost / (1 - CHANNEL_MARGIN_RATE)) * competitor.pricingStrategy.marginMultiplier
+  );
 
   return {
     design,


### PR DESCRIPTION
## Summary
- AI retail price now accounts for EoS-adjusted BOM, assembly, packaging, amortised fixed costs (R&D/tooling/certification), and the 20% channel margin
- Formula: `fullyLoadedCostPerUnit / (1 - CHANNEL_MARGIN_RATE) × marginMultiplier`
- Updated margin multipliers: budget 1.05→1.15, generalist 1.0→1.25, premium 1.15→1.40

## Context
Previously AI pricing was `rawBOM × marginMultiplier`, which ignored assembly/packaging costs, channel margin, and fixed costs. All three AI competitors were losing money on every unit sold (e.g. OmniBook at 1.0× lost ~$85/unit).

Part of #137 (PR 2).

## Test plan
- [ ] Start new game, verify AI competitor prices are in reasonable ranges (~$400-900 depending on archetype and year)
- [ ] Verify AI competitors are profitable (revenue per unit > fully loaded cost)
- [ ] Check budget AI prices < generalist < premium for similar BOM levels