### PR TITLE
feat: AI inventory carryover and VP-based production quantities

### DIFF
--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -109,6 +109,15 @@ function preSimulateAIYear(initial: GameState): GameState {
     };
   }
 
+  // Clean up AI models with no remaining stock before advancing
+  s = {
+    ...s,
+    companies: s.companies.map((comp) => {
+      if (comp.isPlayer) return comp;
+      return { ...comp, models: comp.models.filter((m) => m.unitsInStock > 0) };
+    }),
+  };
+
   // Advance to next year Q1
   return {
     ...s,
@@ -159,37 +168,47 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         currentYearAwards: [],
         brandAwarenessBudget: 0,
         sponsorships: [],
-        companies: updatePlayerModels(companiesAfterSpiral, (models) =>
-          models.map((m) => {
-            if (m.status === "discontinued") return m;
+        companies: companiesAfterSpiral.map((comp) => {
+          if (!comp.isPlayer) {
+            // AI companies: drop models with no remaining stock to prevent state bloat
+            return {
+              ...comp,
+              models: comp.models.filter((m) => m.unitsInStock > 0),
+            };
+          }
+          return {
+            ...comp,
+            models: comp.models.map((m) => {
+              if (m.status === "discontinued") return m;
 
-            // Auto-discontinue drafts/designed models whose components are now obsolete
-            if ((m.status === "draft" || m.status === "designed") && hasDiscontinuedComponents(m.design, nextYear)) {
-              return { ...m, status: "discontinued" as const, manufacturingPlan: null, manufacturingQuantity: null };
-            }
-
-            // Find sim results for this model to get unsold units
-            const simResult = lastSim?.laptopResults.find((r) => r.laptopId === m.design.id);
-            const newStock = simResult ? simResult.unsoldUnits : m.unitsInStock;
-
-            // Models that were manufacturing/onSale transition to onSale
-            if (m.status === "manufacturing" || m.status === "onSale") {
-              const discontinued = hasDiscontinuedComponents(m.design, nextYear);
-
-              if (discontinued && newStock <= 0) {
-                return { ...m, status: "discontinued" as const, unitsInStock: 0, manufacturingPlan: null, manufacturingQuantity: null };
+              // Auto-discontinue drafts/designed models whose components are now obsolete
+              if ((m.status === "draft" || m.status === "designed") && hasDiscontinuedComponents(m.design, nextYear)) {
+                return { ...m, status: "discontinued" as const, manufacturingPlan: null, manufacturingQuantity: null };
               }
 
-              return {
-                ...m,
-                status: "onSale" as const,
-                unitsInStock: newStock,
-              };
-            }
+              // Find sim results for this model to get unsold units
+              const simResult = lastSim?.laptopResults.find((r) => r.laptopId === m.design.id);
+              const newStock = simResult ? simResult.unsoldUnits : m.unitsInStock;
 
-            return m;
-          }),
-        ),
+              // Models that were manufacturing/onSale transition to onSale
+              if (m.status === "manufacturing" || m.status === "onSale") {
+                const discontinued = hasDiscontinuedComponents(m.design, nextYear);
+
+                if (discontinued && newStock <= 0) {
+                  return { ...m, status: "discontinued" as const, unitsInStock: 0, manufacturingPlan: null, manufacturingQuantity: null };
+                }
+
+                return {
+                  ...m,
+                  status: "onSale" as const,
+                  unitsInStock: newStock,
+                };
+              }
+
+              return m;
+            }),
+          };
+        }),
       };
     }
     case "ADD_MODEL":

--- a/src/simulation/competitorAI.ts
+++ b/src/simulation/competitorAI.ts
@@ -34,7 +34,10 @@ import {
   RD_COST,
   TOOLING_COST,
   CERTIFICATION_COST,
+  AI_ORDER_MULTIPLIER,
+  MIN_BATCH_SIZE,
 } from "./tunables";
+import { estimateAnnualDemand } from "./salesEngine";
 
 const COMPONENT_SLOTS: ComponentSlot[] = [
   "cpu", "gpu", "ram", "storage",
@@ -295,24 +298,13 @@ function generateSingleModel(
     unitCost: totals.totalCost,
   };
 
-  // Manufacturing quantity heuristic: base pool size scaled by average brand reach
+  // Preliminary manufacturing quantity (heuristic, used for initial EoS pricing)
   const totalDemand = Object.values(STARTING_DEMAND_POOL).reduce((sum, v) => sum + v, 0);
   const brandFactor = averageReach(competitor.brandReach) / 100;
   const competitorShare = 1 / totalPlayerCount;
   const manufacturingQuantity = Math.round(totalDemand * competitorShare * brandFactor * (0.8 + Math.random() * 0.4));
 
-  // Fully loaded cost: BOM after EoS + assembly + packaging + amortised fixed costs
-  const bomAfterEos = calculateBomUnitCost(totals.totalCost, manufacturingQuantity);
-  const variableCost = bomAfterEos + ASSEMBLY_QA_COST + PACKAGING_LOGISTICS_COST;
-  const modelType = design.modelType;
-  const fixedCosts = RD_COST[modelType] + TOOLING_COST[modelType] + CERTIFICATION_COST[modelType];
-  const amortizedFixed = fixedCosts / manufacturingQuantity;
-  const fullyLoadedCost = variableCost + amortizedFixed;
-
-  // Price covers all costs after retailer takes their 20% cut, times margin
-  const retailPrice = Math.round(
-    (fullyLoadedCost / (1 - CHANNEL_MARGIN_RATE)) * competitor.pricingStrategy.marginMultiplier
-  );
+  const retailPrice = computeAIRetailPrice(design, manufacturingQuantity, competitor);
 
   return {
     design,
@@ -327,16 +319,52 @@ function generateSingleModel(
   };
 }
 
+/** Compute retail price for an AI model given a production quantity. */
+function computeAIRetailPrice(
+  design: LaptopDesign,
+  quantity: number,
+  competitor: CompetitorDefinition,
+): number {
+  const bomAfterEos = calculateBomUnitCost(design.unitCost, quantity);
+  const variableCost = bomAfterEos + ASSEMBLY_QA_COST + PACKAGING_LOGISTICS_COST;
+  const fixedCosts = RD_COST[design.modelType] + TOOLING_COST[design.modelType] + CERTIFICATION_COST[design.modelType];
+  const amortizedFixed = fixedCosts / quantity;
+  const fullyLoadedCost = variableCost + amortizedFixed;
+  return Math.round(
+    (fullyLoadedCost / (1 - CHANNEL_MARGIN_RATE)) * competitor.pricingStrategy.marginMultiplier
+  );
+}
+
 export function generateCompetitorModels(
   year: number,
   competitors: CompetitorDefinition[],
   companies?: CompanyState[],
 ): LaptopModel[] {
   const totalPlayerCount = competitors.length + 1; // +1 for human player
-  return competitors.map((competitor) => {
-    // Read live engineeringBonus from CompanyState (updated by death spiral prevention)
+
+  // Pass 1: generate designs with heuristic quantities and initial pricing
+  const models = competitors.map((competitor) => {
     const companyState = companies?.find((c) => c.id === competitor.id);
     const bonus = companyState?.engineeringBonus ?? competitor.engineeringBonus;
     return generateSingleModel(year, competitor, totalPlayerCount, bonus);
   });
+
+  // Pass 2: if live game context available, refine quantities using VP-based demand
+  if (companies) {
+    const extraModels = competitors.map((c, i) => ({ owner: c.id, model: models[i] }));
+    const demandMap = estimateAnnualDemand({ year, companies }, extraModels);
+
+    for (let i = 0; i < models.length; i++) {
+      const model = models[i];
+      const competitor = competitors[i];
+      const expectedDemand = demandMap.get(model.design.id) ?? model.manufacturingQuantity ?? 0;
+      const quantity = Math.max(MIN_BATCH_SIZE, Math.round(expectedDemand * AI_ORDER_MULTIPLIER[competitor.archetype]));
+
+      model.manufacturingQuantity = quantity;
+      model.unitsInStock = quantity;
+      model.retailPrice = computeAIRetailPrice(model.design, quantity, competitor);
+    }
+  }
+
+  return models;
 }

--- a/src/simulation/salesEngine.ts
+++ b/src/simulation/salesEngine.ts
@@ -98,11 +98,10 @@ function buildMarketLaptops(state: GameState): MarketLaptop[] {
     });
   }
 
-  // Competitor models (current year only)
+  // Competitor models (any with remaining stock)
   for (const comp of state.companies) {
     if (comp.isPlayer) continue;
     for (const model of comp.models) {
-      if (model.yearDesigned !== state.year) continue;
       if (!model.retailPrice || model.unitsInStock <= 0) continue;
 
       const stats = computeStatsForDesign(model.design, state.year);
@@ -555,4 +554,112 @@ export function projectDemandRange(
   const high = Math.round(expected * (1 + variance));
 
   return { low, high, expected };
+}
+
+// --- Annual Demand Estimation (used by AI production planning) ---
+
+/** Minimal context needed for demand estimation (subset of GameState). */
+export interface DemandEstimationContext {
+  year: number;
+  companies: CompanyState[];
+}
+
+/**
+ * Estimate annual demand for every laptop in a market.
+ * Uses the exact VP formula from simulateQuarter (normalised stats, viability
+ * transforms, exponential price scoring, screen penalty, perception bias,
+ * reach multiplier), summed across all demographics and all 4 quarters.
+ * No noise or supply constraints — returns pure expected demand.
+ *
+ * @param ctx         Year and companies (provides brand reach/perception)
+ * @param extraModels Models not yet in ctx.companies (e.g. newly generated AI models)
+ * @returns Map from laptop design id → expected annual units demanded
+ */
+export function estimateAnnualDemand(
+  ctx: DemandEstimationContext,
+  extraModels: { owner: string; model: LaptopModel }[],
+): Map<string, number> {
+  const { year, companies } = ctx;
+  // calculateBiasedVP expects GameState but only reads .year and .companies
+  const stateProxy = ctx as unknown as GameState;
+
+  // Build market: existing models from state + extra models
+  const laptops: MarketLaptop[] = [];
+
+  for (const comp of companies) {
+    for (const model of comp.models) {
+      if (!model.retailPrice || model.unitsInStock <= 0) continue;
+      laptops.push({
+        id: model.design.id,
+        owner: comp.id,
+        model,
+        stats: computeStatsForDesign(model.design, year),
+        retailPrice: model.retailPrice,
+        manufacturingQuantity: model.unitsInStock,
+        totalManufacturingCost: 0,
+      });
+    }
+  }
+
+  for (const { owner, model } of extraModels) {
+    if (!model.retailPrice) continue;
+    laptops.push({
+      id: model.design.id,
+      owner,
+      model,
+      stats: computeStatsForDesign(model.design, year),
+      retailPrice: model.retailPrice,
+      manufacturingQuantity: model.manufacturingQuantity ?? 0,
+      totalManufacturingCost: 0,
+    });
+  }
+
+  if (laptops.length === 0) return new Map();
+
+  // Pre-compute normalised stats
+  const normalisedStatsMap = new Map<string, Record<LaptopStat, number>>();
+  for (const laptop of laptops) {
+    normalisedStatsMap.set(laptop.id, normaliseStats(laptop, year));
+  }
+
+  // Accumulate demand per laptop across all demographics and all 4 quarters
+  const demandMap = new Map<string, number>();
+  for (const laptop of laptops) {
+    demandMap.set(laptop.id, 0);
+  }
+
+  for (const demographic of DEMOGRAPHICS) {
+    const demId = demographic.id;
+    const basePool = STARTING_DEMAND_POOL[demId];
+    const demographicPopulation = getDemandPoolSize(demId, year, basePool);
+    const annualActiveBuyers = demographicPopulation / REPLACEMENT_CYCLE[demId];
+
+    // Compute effective VP for each laptop
+    let totalEffectiveVP = 0;
+    const vpEntries: { laptopId: string; effectiveVP: number }[] = [];
+
+    for (const laptop of laptops) {
+      const normStats = normalisedStatsMap.get(laptop.id)!;
+      const { biasedVP } = calculateBiasedVP(laptop, normStats, demographic, stateProxy);
+
+      const company = companies.find((c) => c.id === laptop.owner);
+      const reach = Math.min(company ? (company.brandReach[demId] ?? 0) : 0, 100);
+      const effectiveVP = biasedVP * (reach / 100);
+
+      vpEntries.push({ laptopId: laptop.id, effectiveVP });
+      totalEffectiveVP += effectiveVP;
+    }
+
+    for (const { laptopId, effectiveVP } of vpEntries) {
+      const share = totalEffectiveVP > 0 ? effectiveVP / totalEffectiveVP : 0;
+      demandMap.set(laptopId, demandMap.get(laptopId)! + annualActiveBuyers * share);
+    }
+  }
+
+  // Round to whole units
+  for (const [id, demand] of demandMap) {
+    demandMap.set(id, Math.round(demand));
+  }
+
+  return demandMap;
 }

--- a/src/simulation/tunables.ts
+++ b/src/simulation/tunables.ts
@@ -5,6 +5,7 @@
  */
 
 import { DemographicId } from "../data/types";
+import { CompetitorArchetype } from "../data/competitors";
 import { ModelType } from "../renderer/state/gameTypes";
 
 // ==================== Brand Reach ====================
@@ -125,6 +126,15 @@ export const QUARTER_SHARES = [8, 4, 2, 1] as const;
 
 /** Sum of all quarter shares for normalisation. */
 export const QUARTER_SHARES_SUM = QUARTER_SHARES.reduce<number>((s, v) => s + v, 0);
+
+// ==================== AI Production ====================
+
+/** Fraction of estimated annual demand each archetype orders */
+export const AI_ORDER_MULTIPLIER: Record<CompetitorArchetype, number> = {
+  budget: 0.80,
+  generalist: 0.90,
+  premium: 1.00,
+};
 
 // ==================== AI Death Spiral Prevention ====================
 


### PR DESCRIPTION
## Summary
- **AI inventory carryover** (issue PR 3): Remove `yearDesigned !== state.year` filter so AI models with remaining stock compete across years. Clean up depleted AI models during year transitions to prevent state bloat.
- **Smart production quantities** (issue PR 4): Replace heuristic manufacturing quantities with VP-based demand estimation using the exact same formula as `simulateQuarter`. Two-pass generation: build designs first, then estimate demand and set `quantity = expectedDemand × archetypeMultiplier` (budget 0.80, generalist 0.90, premium 1.00).

## Changes
- `salesEngine.ts`: Remove year filter for AI in `buildMarketLaptops`; add `estimateAnnualDemand()` export
- `competitorAI.ts`: Two-pass `generateCompetitorModels` with demand-based quantity refinement; extract `computeAIRetailPrice` helper
- `GameContext.tsx`: Filter depleted AI models in `ADVANCE_QUARTER` Q4→Q1 and `preSimulateAIYear`
- `tunables.ts`: Add `AI_ORDER_MULTIPLIER` per archetype

## Test plan
- [ ] Start new game — verify AI competitors appear with reasonable production quantities (not infinite, not tiny)
- [ ] Play through year 1 → year 2: confirm old AI models with leftover stock still appear in market browser
- [ ] Verify AI models with 0 stock are removed during year transition (no state bloat)
- [ ] Check AI pricing is still sensible after quantity adjustment (EoS re-pricing)

Closes #137