### PR TITLE
Fix: clean up results summary redundancy

### DIFF
--- a/src/renderer/screens/HeroKPIBar.tsx
+++ b/src/renderer/screens/HeroKPIBar.tsx
@@ -49,7 +49,7 @@ export function HeroKPIBar({ unitsSold, totalAvailable, revenue, profit, cash, p
     if (Math.abs(diff) >= 0.5) {
       const sign = diff > 0 ? "▲" : "▼";
       const color = diff > 0 ? tokens.colors.success : tokens.colors.danger;
-      sellThroughDelta = { text: `${sign} ${Math.abs(diff).toFixed(0)}pp`, color };
+      sellThroughDelta = { text: `${sign} ${Math.abs(diff).toFixed(0)}%`, color };
     }
   }
 

--- a/src/renderer/screens/QuarterlySummaryScreen.tsx
+++ b/src/renderer/screens/QuarterlySummaryScreen.tsx
@@ -6,7 +6,7 @@ import { MenuButton } from "../shell/MenuButton";
 import { StatusBar } from "../shell/StatusBar";
 import { tokens } from "../shell/tokens";
 import { formatCurrency, formatNumber, QUARTER_LABELS } from "../utils/formatCash";
-import { titleStyle, sectionHeadingStyle, tableStyle, thStyle, tdStyle, tdRight, summaryRowStyle, cardStyle, twoColumnLayout } from "./summaryStyles";
+import { titleStyle, sectionHeadingStyle, tableStyle, thStyle, tdStyle, tdRight, summaryRowStyle, cardStyle, twoColumnLayout, warningBannerStyle } from "./summaryStyles";
 import { reviewScoreColor } from "../utils/reviewScoreColor";
 import { DemographicDetailSection } from "./DemographicDetailSection";
 import { HeroKPIBar } from "./HeroKPIBar";
@@ -149,8 +149,8 @@ export function QuarterlySummaryScreen() {
 
             {/* Unsold inventory warning */}
             {totalUnsold > 0 && (
-              <div style={{ padding: `${tokens.spacing.xs}px ${tokens.spacing.sm}px`, background: "rgba(255, 170, 0, 0.08)", border: `1px solid rgba(255, 170, 0, 0.25)`, borderRadius: tokens.borderRadius.sm, color: tokens.colors.warning, fontSize: tokens.font.sizeSmall, fontWeight: 600, display: "flex", justifyContent: "space-between" }}>
-                <span>Unsold stock remaining</span>
+              <div style={warningBannerStyle}>
+                <span>Unsold (carried to inventory)</span>
                 <span>{formatNumber(totalUnsold)}</span>
               </div>
             )}

--- a/src/renderer/screens/YearEndSummaryScreen.tsx
+++ b/src/renderer/screens/YearEndSummaryScreen.tsx
@@ -7,7 +7,7 @@ import { MenuButton } from "../shell/MenuButton";
 import { StatusBar } from "../shell/StatusBar";
 import { tokens } from "../shell/tokens";
 import { formatCurrency, formatNumber } from "../utils/formatCash";
-import { titleStyle, sectionHeadingStyle, tableStyle, thStyle, tdStyle, tdRight, cardStyle, twoColumnLayout } from "./summaryStyles";
+import { titleStyle, sectionHeadingStyle, tableStyle, thStyle, tdStyle, tdRight, cardStyle, twoColumnLayout, warningBannerStyle } from "./summaryStyles";
 import { AwardsTable } from "./AwardsTable";
 import { AWARD_PERCEPTION_BONUS, AWARD_REACH_BONUS } from "../../simulation/tunables";
 import { DemographicDetailSection } from "./DemographicDetailSection";
@@ -169,7 +169,7 @@ export function YearEndSummaryScreen() {
 
             {/* Unsold inventory warning */}
             {totalUnsold > 0 && (
-              <div style={{ padding: `${tokens.spacing.xs}px ${tokens.spacing.sm}px`, background: "rgba(255, 170, 0, 0.08)", border: `1px solid rgba(255, 170, 0, 0.25)`, borderRadius: tokens.borderRadius.sm, color: tokens.colors.warning, fontSize: tokens.font.sizeSmall, fontWeight: 600, display: "flex", justifyContent: "space-between" }}>
+              <div style={warningBannerStyle}>
                 <span>Unsold (carried to inventory)</span>
                 <span>{formatNumber(totalUnsold)}</span>
               </div>

--- a/src/renderer/screens/summaryStyles.ts
+++ b/src/renderer/screens/summaryStyles.ts
@@ -103,3 +103,16 @@ export const kpiDeltaStyle: CSSProperties = {
   fontSize: tokens.font.sizeSmall,
   fontWeight: 600,
 };
+
+/** Warning banner for unsold inventory, etc. */
+export const warningBannerStyle: CSSProperties = {
+  padding: `${tokens.spacing.xs}px ${tokens.spacing.sm}px`,
+  background: "rgba(255, 170, 0, 0.08)",
+  border: "1px solid rgba(255, 170, 0, 0.25)",
+  borderRadius: tokens.borderRadius.sm,
+  color: tokens.colors.warning,
+  fontSize: tokens.font.sizeSmall,
+  fontWeight: 600,
+  display: "flex",
+  justifyContent: "space-between",
+};


### PR DESCRIPTION
## Summary
- **Remove redundant Financial Details cards** from both quarterly and year-end screens — revenue, profit, and cash are already in the hero KPI bar. Quarterly screen keeps only the YTD revenue line; year-end keeps only the unsold inventory warning.
- **Drop "▲ New" delta** when previous period was zero — no delta is shown instead of a confusing label.
- **Show sell-through % as hero KPI** for units (e.g. "87%") with "1,200 of 2,000 units" as subtitle, replacing the fraction format.

Closes #144

## Test plan
- [ ] Play through Q1 → verify KPI bar shows sell-through %, subtitle with raw counts, and no "▲ New" labels
- [ ] Verify quarterly screen shows only a YTD revenue row in the right column (no duplicated cash/revenue/profit)
- [ ] Play through Q4 → verify year-end screen shows unsold warning only when unsold > 0, no redundant financial card
- [ ] Switch between Annual / Q4 views — deltas should still work correctly