### PR TITLE
Fix: auto-carry-forward manufacturing plans across year boundary

### DIFF
--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -205,10 +205,16 @@ function gameReducer(state: GameState, action: GameAction): GameState {
                   return { ...m, status: "discontinued" as const, unitsInStock: 0, manufacturingPlan: null, manufacturingQuantity: null };
                 }
 
+                // Auto-carry-forward manufacturing plan for non-discontinued models
+                const carriedPlan = !discontinued && m.manufacturingPlan
+                  ? { ...m.manufacturingPlan, year: nextYear, quarter: 1 as const }
+                  : null;
+
                 return {
                   ...m,
                   status: "onSale" as const,
                   unitsInStock: newStock,
+                  manufacturingPlan: carriedPlan,
                 };
               }
 


### PR DESCRIPTION
## Summary
- Fixes #146: Year transition no longer forces players to recreate manufacturing plans for continuing models
- In the `ADVANCE_QUARTER` reducer, non-discontinued models now have their `manufacturingPlan` carried forward with the updated year/quarter, so `modelsNeedingPlans()` recognizes them as ready

## Test plan
- [ ] Start a game, design a model, set a manufacturing plan, and simulate through all 4 quarters
- [ ] Verify that on Q1 of the new year, continuing models show as ready (no "Add manufacturing plans" warning)
- [ ] Verify that models with discontinued components do NOT get plans carried forward
- [ ] Verify the player can still adjust carried-forward plans via Model Management