### PR TITLE
Fix: auto-discontinue retail-only models when stock hits 0

### DIFF
--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -363,9 +363,8 @@ function gameReducer(state: GameState, action: GameAction): GameState {
             brandPerception: newPlayerPerception,
             models: comp.models.map((m) => {
               const sim = simByLaptop.get(m.design.id);
-              if (!sim || !m.manufacturingPlan) return m;
+              if (!sim) return m;
 
-              const existingResults = m.manufacturingPlan.results;
               const updatedStock = sim.unsoldUnits;
 
               // Auto-discontinue retail-only models that have sold out
@@ -379,6 +378,12 @@ function gameReducer(state: GameState, action: GameAction): GameState {
                 };
               }
 
+              // No manufacturing plan — just update stock (retail-only clearance sales)
+              if (!m.manufacturingPlan) {
+                return { ...m, unitsInStock: updatedStock };
+              }
+
+              const existingResults = m.manufacturingPlan.results;
               return {
                 ...m,
                 // Update units in stock after quarter sales


### PR DESCRIPTION
## Summary
- Auto-discontinues models with discontinued components (retail-only) when their stock reaches 0 during quarter simulation, rather than only at year boundaries

Closes #148

## What changed
In `APPLY_QUARTER_RESULT`, after updating a model's stock from sim results, we now check if the model has 0 remaining stock and has discontinued components. If so, the model is immediately set to `"discontinued"` status with its manufacturing plan cleared.

Previously, this auto-discontinue only happened at year transitions (`ADVANCE_QUARTER`), meaning retail-only models that sold out mid-year would sit as dead "On Sale" entries until the next year boundary.

## Test plan
- [ ] Create a model, manufacture it, then advance time until its components become discontinued
- [ ] Verify that once the model sells out (0 stock), it auto-discontinues immediately after the quarter sim
- [ ] Verify models with stock remaining but discontinued components still show as retail-only (not auto-discontinued)
- [ ] Verify models with 0 stock but valid components are NOT auto-discontinued (player can still manufacture)