### PR TITLE
fix: Q1 manufacturing plan no longer forces repeat of previous year's order

### DIFF
--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -210,16 +210,11 @@ function gameReducer(state: GameState, action: GameAction): GameState {
                   return { ...m, status: "discontinued" as const, unitsInStock: 0, manufacturingPlan: null, manufacturingQuantity: null };
                 }
 
-                // Auto-carry-forward manufacturing plan for non-discontinued models
-                const carriedPlan = !discontinued && m.manufacturingPlan
-                  ? { ...m.manufacturingPlan, year: nextYear, quarter: 1 as const }
-                  : null;
-
                 return {
                   ...m,
                   status: "onSale" as const,
                   unitsInStock: newStock,
-                  manufacturingPlan: carriedPlan,
+                  manufacturingPlan: null,
                 };
               }
 


### PR DESCRIPTION
## Summary
- Removed the carry-forward logic that copied the previous year's manufacturing plan into Q1, forcing players to repeat their order
- Q1 now starts with a fresh plan, consistent with Q2-Q4

Closes #167