### PR TITLE
fix: show top 5 demographics in BrandCard instead of all 20

### DIFF
--- a/src/renderer/screens/dashboard/BrandCard.tsx
+++ b/src/renderer/screens/dashboard/BrandCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Sparkles } from "lucide-react";
 import { useGame } from "../../state/GameContext";
 import { getPlayerCompany } from "../../state/gameTypes";
@@ -9,40 +10,73 @@ import { formatPerception } from "./utils";
 
 import { DEMOGRAPHICS } from "../../../data/demographics";
 
+const TOP_N = 5;
+
 export function BrandCard() {
   const { state } = useGame();
   const player = getPlayerCompany(state);
 
+  const topReach = useMemo(() => {
+    const entries = DEMOGRAPHICS.map((dem) => ({
+      dem,
+      value: Math.round(player.brandReach[dem.id] ?? 0),
+    }));
+    entries.sort((a, b) => b.value - a.value);
+    return entries;
+  }, [player.brandReach]);
+
+  const topPerception = useMemo(() => {
+    const entries = DEMOGRAPHICS.map((dem) => ({
+      dem,
+      value: player.brandPerception[dem.id] ?? 0,
+    }));
+    entries.sort((a, b) => Math.abs(b.value) - Math.abs(a.value));
+    return entries;
+  }, [player.brandPerception]);
+
+  const shownReach = topReach.slice(0, TOP_N);
+  const hiddenReachCount = topReach.length - TOP_N;
+
+  const shownPerception = topPerception.slice(0, TOP_N);
+  const hiddenPerceptionCount = topPerception.length - TOP_N;
+
   return (
     <BentoCard title="Brand" icon={Sparkles} screen="brandDetail">
       <p style={{ ...sectionHeadingStyle, marginBottom: tokens.spacing.sm }}>Brand Reach</p>
-      {DEMOGRAPHICS.map((dem) => {
-        const reach = Math.round(player.brandReach[dem.id] ?? 0);
-        return (
-          <div key={dem.id} style={{ display: "flex", alignItems: "center", gap: tokens.spacing.sm, marginTop: tokens.spacing.xs }}>
-            <span style={{ ...smallTextStyle, minWidth: 130, flexShrink: 0 }}>{dem.name}</span>
-            <ProgressBar value={reach} height={6} />
-            <span style={{ ...smallTextStyle, minWidth: 36, textAlign: "right" }}>{reach}%</span>
-          </div>
-        );
-      })}
+      {shownReach.map(({ dem, value }) => (
+        <div key={dem.id} style={{ display: "flex", alignItems: "center", gap: tokens.spacing.sm, marginTop: tokens.spacing.xs }}>
+          <span style={{ ...smallTextStyle, minWidth: 130, flexShrink: 0 }}>{dem.shortName}</span>
+          <ProgressBar value={value} height={6} />
+          <span style={{ ...smallTextStyle, minWidth: 36, textAlign: "right" }}>{value}%</span>
+        </div>
+      ))}
+      {hiddenReachCount > 0 && (
+        <p style={{ ...smallTextStyle, marginTop: tokens.spacing.xs, color: tokens.colors.textMuted }}>
+          +{hiddenReachCount} more demographics
+        </p>
+      )}
       <p style={{ ...hintStyle, marginTop: tokens.spacing.xs }}>
         Percentage of each demographic that has heard of your company
       </p>
 
       <div style={sectionDividerStyle}>
         <p style={sectionHeadingStyle}>Brand Perception</p>
-        {DEMOGRAPHICS.map((dem) => {
-          const perception = formatPerception(player.brandPerception[dem.id] ?? 0);
+        {shownPerception.map(({ dem, value }) => {
+          const perception = formatPerception(value);
           return (
             <div key={dem.id} style={{ display: "flex", alignItems: "center", gap: tokens.spacing.sm, marginTop: tokens.spacing.xs }}>
-              <span style={{ ...smallTextStyle, minWidth: 130, flexShrink: 0 }}>{dem.name}</span>
+              <span style={{ ...smallTextStyle, minWidth: 130, flexShrink: 0 }}>{dem.shortName}</span>
               <span style={{ ...cardBodyStyle, fontSize: 14, minWidth: 50, textAlign: "right", color: perception.color }}>
                 {perception.sign}{perception.value}
               </span>
             </div>
           );
         })}
+        {hiddenPerceptionCount > 0 && (
+          <p style={{ ...smallTextStyle, marginTop: tokens.spacing.xs, color: tokens.colors.textMuted }}>
+            +{hiddenPerceptionCount} more demographics
+          </p>
+        )}
         <p style={{ ...hintStyle, marginTop: tokens.spacing.xs }}>
           Accumulated sentiment — positive = benefit of the doubt, negative = scepticism
         </p>


### PR DESCRIPTION
## Summary
- BrandCard now shows only the **top 5** demographics for each section (reach sorted by value, perception sorted by absolute value) instead of all 20
- Uses `shortName` for more compact labels
- Adds "+N more demographics" hint for the hidden entries

Closes #168

## Test plan
- [ ] Open dashboard and verify BrandCard shows only 5 reach rows + 5 perception rows
- [ ] Verify the top 5 are sorted correctly (highest reach first, highest |perception| first)
- [ ] Verify "+15 more demographics" text appears below each section
- [ ] Click through to Brand Detail screen and verify all 20 demographics still show there