### PR TITLE
fix: charge tooling/cert only on first production run

### DIFF
--- a/src/renderer/manufacturing/steps/ManufacturingStep.tsx
+++ b/src/renderer/manufacturing/steps/ManufacturingStep.tsx
@@ -191,8 +191,10 @@ export function ManufacturingStep() {
   const modelType = model?.design.modelType ?? "brandNew";
   const activeModelCount = getActiveModels(gameState).length;
 
-  const toolingCost = TOOLING_COST[modelType];
-  const certCost = CERTIFICATION_COST[modelType];
+  // Tooling + certification are one-time costs: only charged on the first production run
+  const isFirstRun = !state.isAdditionalOrder;
+  const toolingCost = isFirstRun ? TOOLING_COST[modelType] : 0;
+  const certCost = isFirstRun ? CERTIFICATION_COST[modelType] : 0;
   const overhead = activeModelCount > 1 ? MULTI_MODEL_OVERHEAD : 0;
 
   // Fixed costs that must be paid regardless

--- a/src/renderer/manufacturing/utils/economiesOfScale.ts
+++ b/src/renderer/manufacturing/utils/economiesOfScale.ts
@@ -99,8 +99,11 @@ export function buildCostBreakdown(gameState: GameState, wizardState: Pick<Manuf
   const activeModelCount = getActiveModels(gameState).length;
   const overhead = activeModelCount > 1 ? MULTI_MODEL_OVERHEAD : 0;
 
-  // If ordering 0 new units (inventory-only), no manufacturing fixed costs apply
+  // If ordering 0 new units (inventory-only), no manufacturing fixed costs apply.
+  // Tooling + certification are one-time costs: only charged on the first production run.
+  // A model that's already "manufacturing" or "onSale" has already paid these.
   const orderingNew = wizardState.unitsOrdered > 0;
+  const isFirstRun = model?.status === "designed" || model?.status === "draft";
   const cost = calculateCostBreakdown({
     baseBomCost,
     unitsOrdered: wizardState.unitsOrdered,
@@ -108,8 +111,8 @@ export function buildCostBreakdown(gameState: GameState, wizardState: Pick<Manuf
     assemblyQa: ASSEMBLY_QA_COST,
     packagingLogistics: PACKAGING_LOGISTICS_COST,
     channelMarginRate: CHANNEL_MARGIN_RATE,
-    toolingCost: orderingNew ? TOOLING_COST[modelType] : 0,
-    certificationCost: orderingNew ? CERTIFICATION_COST[modelType] : 0,
+    toolingCost: orderingNew && isFirstRun ? TOOLING_COST[modelType] : 0,
+    certificationCost: orderingNew && isFirstRun ? CERTIFICATION_COST[modelType] : 0,
     multiModelOverhead: orderingNew ? overhead : 0,
   });
 


### PR DESCRIPTION
## Summary
- Tooling ($800K) and certification ($50K) fixed costs were being charged on every manufacturing order. They are now correctly charged only on the first production run of a model.
- `buildCostBreakdown` checks model status (`designed`/`draft` = first run); `ManufacturingStep` uses `isAdditionalOrder` flag.

## Test plan
- [ ] Design a new model, confirm first manufacturing order — should show tooling + cert costs
- [ ] Reopen manufacturing wizard for same model in a later quarter — tooling + cert should be $0
- [ ] Max quantity slider should reflect higher budget on additional orders (no fixed cost deduction)

Closes #176