### PR TITLE
Sort market overview by buyers and add filters

### DIFF
--- a/src/renderer/screens/MarketOverviewScreen.tsx
+++ b/src/renderer/screens/MarketOverviewScreen.tsx
@@ -191,7 +191,7 @@ export function MarketOverviewScreen() {
       return true;
     });
 
-    return [...filtered].sort((a, b) => {
+    return filtered.sort((a, b) => {
       switch (sortBy) {
         case "buyers":
           return getAnnualBuyers(b.id, state.year) - getAnnualBuyers(a.id, state.year);


### PR DESCRIPTION
## Summary
- Default sort by annual buyers (descending), with options for price ceiling and name
- Tier filter: All / Generalist / Niche
- Price sensitivity filter: All / Very Price Sensitive / Price Sensitive / Moderate / Price Insensitive
- Shows count of matching demographics
- Uses CustomSelect for all dropdowns