### PR TITLE
feat: group wizard components by year with accordion

### DIFF
--- a/src/renderer/wizard/steps/ComponentStepLayout.tsx
+++ b/src/renderer/wizard/steps/ComponentStepLayout.tsx
@@ -88,6 +88,7 @@ function groupByYear(components: Component[], minSize: number, gameYear: number)
 }
 
 const AGING_THRESHOLD_QUARTERS = 5;
+const AGING_OPACITY = 0.55;
 
 /** Returns true if a component is 5+ quarters old relative to the current game date. */
 function isAging(component: Component, gameYear: number, gameQuarter: 1 | 2 | 3 | 4): boolean {
@@ -183,27 +184,15 @@ function SlotSection({
       </div>
 
       {singleGroup ? (
-        <div
-          style={{
-            display: "flex",
-            flexWrap: "wrap",
-            alignItems: "flex-start",
-            gap: "8px",
-          }}
-        >
-          {groups[0]?.components.map((component) => (
-            <ComponentCard
-              key={component.id}
-              component={component}
-              isSelected={selected?.id === component.id}
-              onSelect={() => onSelect(component)}
-              slot={slot}
-              multiplier={multiplier}
-              gameYear={gameYear}
-              gameQuarter={gameQuarter}
-            />
-          ))}
-        </div>
+        <ComponentGrid
+          components={groups[0]?.components ?? []}
+          selected={selected}
+          onSelect={onSelect}
+          slot={slot}
+          multiplier={multiplier}
+          gameYear={gameYear}
+          gameQuarter={gameQuarter}
+        />
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
           {groups.map((group, idx) => {
@@ -253,34 +242,67 @@ function SlotSection({
                   )}
                 </button>
                 {isExpanded && (
-                  <div
-                    style={{
-                      display: "flex",
-                      flexWrap: "wrap",
-                      alignItems: "flex-start",
-                      gap: "8px",
-                      padding: "4px 0 8px",
-                    }}
-                  >
-                    {group.components.map((component) => (
-                      <ComponentCard
-                        key={component.id}
-                        component={component}
-                        isSelected={selected?.id === component.id}
-                        onSelect={() => onSelect(component)}
-                        slot={slot}
-                        multiplier={multiplier}
-                        gameYear={gameYear}
-                        gameQuarter={gameQuarter}
-                      />
-                    ))}
-                  </div>
+                  <ComponentGrid
+                    components={group.components}
+                    selected={selected}
+                    onSelect={onSelect}
+                    slot={slot}
+                    multiplier={multiplier}
+                    gameYear={gameYear}
+                    gameQuarter={gameQuarter}
+                    style={{ padding: "4px 0 8px" }}
+                  />
                 )}
               </div>
             );
           })}
         </div>
       )}
+    </div>
+  );
+}
+
+function ComponentGrid({
+  components,
+  selected,
+  onSelect,
+  slot,
+  multiplier,
+  gameYear,
+  gameQuarter,
+  style,
+}: {
+  components: Component[];
+  selected: Component | null;
+  onSelect: (component: Component) => void;
+  slot: ComponentSlot;
+  multiplier: number;
+  gameYear: number;
+  gameQuarter: 1 | 2 | 3 | 4;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "flex-start",
+        gap: "8px",
+        ...style,
+      }}
+    >
+      {components.map((component) => (
+        <ComponentCard
+          key={component.id}
+          component={component}
+          isSelected={selected?.id === component.id}
+          onSelect={() => onSelect(component)}
+          slot={slot}
+          multiplier={multiplier}
+          gameYear={gameYear}
+          gameQuarter={gameQuarter}
+        />
+      ))}
     </div>
   );
 }
@@ -312,7 +334,7 @@ function ComponentCard({
       <SelectionCard isSelected={isSelected} onClick={onSelect}>
         <div
           style={{
-            opacity: aging && !isSelected ? 0.55 : 1,
+            opacity: aging && !isSelected ? AGING_OPACITY : 1,
             transition: "opacity 0.15s",
           }}
         >

--- a/src/renderer/wizard/steps/ComponentStepLayout.tsx
+++ b/src/renderer/wizard/steps/ComponentStepLayout.tsx
@@ -21,6 +21,16 @@ interface YearGroup {
   components: Component[];
 }
 
+function makeGroupLabel(years: number[]): string {
+  const sorted = [...years].sort((a, b) => a - b);
+  return sorted.length === 1
+    ? `${sorted[0]}`
+    : `${sorted[0]}\u2013${sorted[sorted.length - 1]}`;
+}
+
+const sortCheapestFirst = (gameYear: number) => (a: Component, b: Component) =>
+  componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear);
+
 /** Group components by year (newest first), merging small groups so each has >= minSize items. */
 function groupByYear(components: Component[], minSize: number, gameYear: number): YearGroup[] {
   // Bucket by yearIntroduced
@@ -36,7 +46,7 @@ function groupByYear(components: Component[], minSize: number, gameYear: number)
 
   // Sort each bucket cheapest-first (by decayed cost)
   for (const [, items] of buckets) {
-    items.sort((a, b) => componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear));
+    items.sort(sortCheapestFirst(gameYear));
   }
 
   // Build groups, merging from the tail (oldest) until each has >= minSize
@@ -51,13 +61,8 @@ function groupByYear(components: Component[], minSize: number, gameYear: number)
     pendingItems.push(...buckets.get(year)!);
 
     if (pendingItems.length >= minSize) {
-      // Re-sort merged group cheapest-first
-      pendingItems.sort((a, b) => componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear));
-      const sortedYears = pendingYears.sort((a, b) => a - b);
-      const label = sortedYears.length === 1
-        ? `${sortedYears[0]}`
-        : `${sortedYears[0]}\u2013${sortedYears[sortedYears.length - 1]}`;
-      groups.push({ label, components: pendingItems });
+      pendingItems.sort(sortCheapestFirst(gameYear));
+      groups.push({ label: makeGroupLabel(pendingYears), components: pendingItems });
       pendingYears = [];
       pendingItems = [];
     }
@@ -68,19 +73,12 @@ function groupByYear(components: Component[], minSize: number, gameYear: number)
     if (groups.length > 0) {
       const last = groups[groups.length - 1];
       last.components.push(...pendingItems);
-      last.components.sort((a, b) => componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear));
-      // Update label to include the merged years
-      const allYears = [...new Set(last.components.map((c) => c.yearIntroduced))].sort((a, b) => a - b);
-      last.label = allYears.length === 1
-        ? `${allYears[0]}`
-        : `${allYears[0]}\u2013${allYears[allYears.length - 1]}`;
+      last.components.sort(sortCheapestFirst(gameYear));
+      const allYears = [...new Set(last.components.map((c) => c.yearIntroduced))];
+      last.label = makeGroupLabel(allYears);
     } else {
-      pendingItems.sort((a, b) => componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear));
-      const sortedYears = pendingYears.sort((a, b) => a - b);
-      const label = sortedYears.length === 1
-        ? `${sortedYears[0]}`
-        : `${sortedYears[0]}\u2013${sortedYears[sortedYears.length - 1]}`;
-      groups.push({ label, components: pendingItems });
+      pendingItems.sort(sortCheapestFirst(gameYear));
+      groups.push({ label: makeGroupLabel(pendingYears), components: pendingItems });
     }
   }
 
@@ -89,11 +87,13 @@ function groupByYear(components: Component[], minSize: number, gameYear: number)
   return groups;
 }
 
+const AGING_THRESHOLD_QUARTERS = 5;
+
 /** Returns true if a component is 5+ quarters old relative to the current game date. */
 function isAging(component: Component, gameYear: number, gameQuarter: number): boolean {
   const gameQ = gameYear * 4 + gameQuarter;
   const compQ = component.yearIntroduced * 4 + (component.quarterIntroduced ?? 1);
-  return gameQ - compQ >= 5;
+  return gameQ - compQ >= AGING_THRESHOLD_QUARTERS;
 }
 
 export function ComponentStepLayout({
@@ -300,7 +300,7 @@ function ComponentCard({
   slot: ComponentSlot;
   multiplier: number;
   gameYear: number;
-  gameQuarter: number;
+  gameQuarter: 1 | 2 | 3 | 4;
 }) {
   const cost = applyDisplayMultiplier(componentCostDecayed(component, gameYear), slot, multiplier);
   const power = applyDisplayMultiplier(component.powerDrawW, slot, multiplier);

--- a/src/renderer/wizard/steps/ComponentStepLayout.tsx
+++ b/src/renderer/wizard/steps/ComponentStepLayout.tsx
@@ -90,7 +90,7 @@ function groupByYear(components: Component[], minSize: number, gameYear: number)
 const AGING_THRESHOLD_QUARTERS = 5;
 
 /** Returns true if a component is 5+ quarters old relative to the current game date. */
-function isAging(component: Component, gameYear: number, gameQuarter: number): boolean {
+function isAging(component: Component, gameYear: number, gameQuarter: 1 | 2 | 3 | 4): boolean {
   const gameQ = gameYear * 4 + gameQuarter;
   const compQ = component.yearIntroduced * 4 + (component.quarterIntroduced ?? 1);
   return gameQ - compQ >= AGING_THRESHOLD_QUARTERS;

--- a/src/renderer/wizard/steps/ComponentStepLayout.tsx
+++ b/src/renderer/wizard/steps/ComponentStepLayout.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useWizard } from "../WizardContext";
 import { DISPLAY_SLOTS, applyDisplayMultiplier, specSummary, getAvailableComponents, componentCostDecayed } from "../../../data/designConstants";
 import { getScreenSizeDef } from "../../../data/screenSizes";
@@ -13,6 +14,86 @@ export interface SlotDef {
 
 function isDisplaySlot(slot: ComponentSlot): boolean {
   return DISPLAY_SLOTS.includes(slot);
+}
+
+interface YearGroup {
+  label: string;
+  components: Component[];
+}
+
+/** Group components by year (newest first), merging small groups so each has >= minSize items. */
+function groupByYear(components: Component[], minSize: number, gameYear: number): YearGroup[] {
+  // Bucket by yearIntroduced
+  const buckets = new Map<number, Component[]>();
+  for (const c of components) {
+    const year = c.yearIntroduced;
+    if (!buckets.has(year)) buckets.set(year, []);
+    buckets.get(year)!.push(c);
+  }
+
+  // Sort years newest-first
+  const years = [...buckets.keys()].sort((a, b) => b - a);
+
+  // Sort each bucket cheapest-first (by decayed cost)
+  for (const [, items] of buckets) {
+    items.sort((a, b) => componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear));
+  }
+
+  // Build groups, merging from the tail (oldest) until each has >= minSize
+  const groups: YearGroup[] = [];
+  let pendingYears: number[] = [];
+  let pendingItems: Component[] = [];
+
+  // Walk oldest to newest so we merge old years upward
+  for (let i = years.length - 1; i >= 0; i--) {
+    const year = years[i];
+    pendingYears.push(year);
+    pendingItems.push(...buckets.get(year)!);
+
+    if (pendingItems.length >= minSize) {
+      // Re-sort merged group cheapest-first
+      pendingItems.sort((a, b) => componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear));
+      const sortedYears = pendingYears.sort((a, b) => a - b);
+      const label = sortedYears.length === 1
+        ? `${sortedYears[0]}`
+        : `${sortedYears[0]}\u2013${sortedYears[sortedYears.length - 1]}`;
+      groups.push({ label, components: pendingItems });
+      pendingYears = [];
+      pendingItems = [];
+    }
+  }
+
+  // Flush remainder — merge into the last group if it exists, otherwise create one
+  if (pendingItems.length > 0) {
+    if (groups.length > 0) {
+      const last = groups[groups.length - 1];
+      last.components.push(...pendingItems);
+      last.components.sort((a, b) => componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear));
+      // Update label to include the merged years
+      const allYears = [...new Set(last.components.map((c) => c.yearIntroduced))].sort((a, b) => a - b);
+      last.label = allYears.length === 1
+        ? `${allYears[0]}`
+        : `${allYears[0]}\u2013${allYears[allYears.length - 1]}`;
+    } else {
+      pendingItems.sort((a, b) => componentCostDecayed(a, gameYear) - componentCostDecayed(b, gameYear));
+      const sortedYears = pendingYears.sort((a, b) => a - b);
+      const label = sortedYears.length === 1
+        ? `${sortedYears[0]}`
+        : `${sortedYears[0]}\u2013${sortedYears[sortedYears.length - 1]}`;
+      groups.push({ label, components: pendingItems });
+    }
+  }
+
+  // Reverse so newest group is first
+  groups.reverse();
+  return groups;
+}
+
+/** Returns true if a component is 5+ quarters old relative to the current game date. */
+function isAging(component: Component, gameYear: number, gameQuarter: number): boolean {
+  const gameQ = gameYear * 4 + gameQuarter;
+  const compQ = component.yearIntroduced * 4 + (component.quarterIntroduced ?? 1);
+  return gameQ - compQ >= 5;
 }
 
 export function ComponentStepLayout({
@@ -54,6 +135,8 @@ export function ComponentStepLayout({
   );
 }
 
+const MIN_GROUP_SIZE = 4;
+
 function SlotSection({
   slot,
   label,
@@ -73,6 +156,20 @@ function SlotSection({
 }) {
   const available = getAvailableComponents(slot, gameYear, gameQuarter);
   const multiplier = screenSizeDef.displayMultiplier;
+  const groups = groupByYear(available, MIN_GROUP_SIZE, gameYear);
+
+  // Find which group contains the selected component (if any)
+  const selectedGroupIdx = selected
+    ? groups.findIndex((g) => g.components.some((c) => c.id === selected.id))
+    : -1;
+
+  // Default expanded: group containing selected component, or the newest group (index 0)
+  const [expandedIdx, setExpandedIdx] = useState<number>(
+    selectedGroupIdx >= 0 ? selectedGroupIdx : 0,
+  );
+
+  // If only one group, skip the accordion entirely
+  const singleGroup = groups.length <= 1;
 
   return (
     <div style={{ marginBottom: "24px" }}>
@@ -84,26 +181,106 @@ function SlotSection({
           </span>
         )}
       </div>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "flex-start",
-          gap: "8px",
-        }}
-      >
-        {available.map((component) => (
-          <ComponentCard
-            key={component.id}
-            component={component}
-            isSelected={selected?.id === component.id}
-            onSelect={() => onSelect(component)}
-            slot={slot}
-            multiplier={multiplier}
-            gameYear={gameYear}
-          />
-        ))}
-      </div>
+
+      {singleGroup ? (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "flex-start",
+            gap: "8px",
+          }}
+        >
+          {groups[0]?.components.map((component) => (
+            <ComponentCard
+              key={component.id}
+              component={component}
+              isSelected={selected?.id === component.id}
+              onSelect={() => onSelect(component)}
+              slot={slot}
+              multiplier={multiplier}
+              gameYear={gameYear}
+              gameQuarter={gameQuarter}
+            />
+          ))}
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+          {groups.map((group, idx) => {
+            const isExpanded = expandedIdx === idx;
+            const hasSelection = selected
+              ? group.components.some((c) => c.id === selected.id)
+              : false;
+
+            return (
+              <div key={group.label}>
+                <button
+                  onClick={() => setExpandedIdx(isExpanded ? -1 : idx)}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "6px",
+                    width: "100%",
+                    background: "none",
+                    border: "none",
+                    color: hasSelection ? tokens.colors.interactiveAccent : "#aaa",
+                    fontSize: "0.75rem",
+                    fontWeight: "bold",
+                    cursor: "pointer",
+                    padding: "6px 0",
+                    fontFamily: "inherit",
+                    textAlign: "left",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: "0.625rem",
+                      display: "inline-block",
+                      transform: isExpanded ? "rotate(0deg)" : "rotate(-90deg)",
+                      transition: "transform 0.15s",
+                    }}
+                  >
+                    &#9660;
+                  </span>
+                  <span>{group.label}</span>
+                  <span style={{ color: "#666", fontWeight: "normal" }}>
+                    ({group.components.length})
+                  </span>
+                  {hasSelection && selected && (
+                    <span style={{ color: tokens.colors.interactiveAccent, fontWeight: "normal", marginLeft: "auto" }}>
+                      {selected.name}
+                    </span>
+                  )}
+                </button>
+                {isExpanded && (
+                  <div
+                    style={{
+                      display: "flex",
+                      flexWrap: "wrap",
+                      alignItems: "flex-start",
+                      gap: "8px",
+                      padding: "4px 0 8px",
+                    }}
+                  >
+                    {group.components.map((component) => (
+                      <ComponentCard
+                        key={component.id}
+                        component={component}
+                        isSelected={selected?.id === component.id}
+                        onSelect={() => onSelect(component)}
+                        slot={slot}
+                        multiplier={multiplier}
+                        gameYear={gameYear}
+                        gameQuarter={gameQuarter}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }
@@ -115,6 +292,7 @@ function ComponentCard({
   slot,
   multiplier,
   gameYear,
+  gameQuarter,
 }: {
   component: Component;
   isSelected: boolean;
@@ -122,32 +300,41 @@ function ComponentCard({
   slot: ComponentSlot;
   multiplier: number;
   gameYear: number;
+  gameQuarter: number;
 }) {
   const cost = applyDisplayMultiplier(componentCostDecayed(component, gameYear), slot, multiplier);
   const power = applyDisplayMultiplier(component.powerDrawW, slot, multiplier);
   const weight = applyDisplayMultiplier(component.weightG, slot, multiplier);
+  const aging = isAging(component, gameYear, gameQuarter);
 
   return (
     <Tooltip content={<OptionTooltipContent name={component.name} description={component.description} stats={component.stats} />}>
       <SelectionCard isSelected={isSelected} onClick={onSelect}>
         <div
           style={{
-            fontSize: "0.8125rem",
-            fontWeight: "bold",
-            marginBottom: "6px",
-            color: isSelected ? tokens.colors.interactiveAccent : "#e0e0e0",
+            opacity: aging && !isSelected ? 0.55 : 1,
+            transition: "opacity 0.15s",
           }}
         >
-          {component.name}
-        </div>
-        <div style={{ fontSize: "0.6875rem", color: "#888", marginBottom: "8px", lineHeight: "1.4" }}>
-          {specSummary(component.specs)}
-        </div>
-        <div style={{ display: "flex", gap: "12px", fontSize: "0.6875rem" }}>
-          <span style={{ color: "#4caf50" }}>${cost}</span>
-          {power > 0 && <span style={{ color: "#ff9800" }}>{power}W</span>}
-          {weight > 0 && <span style={{ color: "#888" }}>{weight}g</span>}
-          <span style={{ color: "#666" }}>{component.yearIntroduced}</span>
+          <div
+            style={{
+              fontSize: "0.8125rem",
+              fontWeight: "bold",
+              marginBottom: "6px",
+              color: isSelected ? tokens.colors.interactiveAccent : "#e0e0e0",
+            }}
+          >
+            {component.name}
+          </div>
+          <div style={{ fontSize: "0.6875rem", color: "#888", marginBottom: "8px", lineHeight: "1.4" }}>
+            {specSummary(component.specs)}
+          </div>
+          <div style={{ display: "flex", gap: "12px", fontSize: "0.6875rem" }}>
+            <span style={{ color: "#4caf50" }}>${cost}</span>
+            {power > 0 && <span style={{ color: "#ff9800" }}>{power}W</span>}
+            {weight > 0 && <span style={{ color: "#888" }}>{weight}g</span>}
+            <span style={{ color: "#666" }}>{component.yearIntroduced}</span>
+          </div>
         </div>
       </SelectionCard>
     </Tooltip>


### PR DESCRIPTION
## Summary
- Components in the design wizard are now grouped by year (newest first) with collapsible accordion headers
- Only one year group is expanded at a time per slot — expanding one collapses the rest
- Small year groups are merged so every group has at least 4 items (e.g. "2013–2015" instead of three sparse groups)
- Within each group, components are sorted cheapest-first (by decayed cost at current game year)
- Components 5+ quarters old render at reduced opacity (0.55) as a subtle aging indicator — still fully selectable
- If a component is already selected, its group auto-expands and the selected component name is shown in the group header
- Slots with only one group skip the accordion entirely (no unnecessary headers)

## Test plan
- [ ] Open design wizard in an early year (e.g. 2003) — slots should have few groups, some may skip accordion
- [ ] Open design wizard in a late year (e.g. 2024) — CPU/GPU should have multiple year groups, newest expanded by default
- [ ] Click a group header to expand it — the previously expanded group should collapse
- [ ] Select a component from an older group, navigate away and back — the group with the selection should be expanded
- [ ] Verify aging indicator: components from 5+ quarters ago should appear slightly faded
- [ ] Verify faded components are still clickable and selectable
- [ ] Check display step slots with screen size multiplier — multiplier label should still appear