### PR TITLE
fix: core manufacturing and review bugs (#243, #242, #239, #229, #237)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.tsbuildinfo
 agents/
 .claude/
+.agent/

--- a/src/renderer/manufacturing/steps/ManufacturingStep.tsx
+++ b/src/renderer/manufacturing/steps/ManufacturingStep.tsx
@@ -205,8 +205,18 @@ export function ManufacturingStep() {
   const minPrice = Math.max(snapPrice(baseTotalPerUnit * MIN_PRICE_MULTIPLIER), MIN_RETAIL_PRICE);
   const maxPrice = snapPrice(baseTotalPerUnit * MAX_PRICE_MULTIPLIER);
 
+  // Other models' committed manufacturing costs for this quarter (cash not yet deducted — only deducted at simulation)
+  const otherPlansCost = player.models
+    .filter((m) =>
+      m.design.id !== state.modelId &&
+      m.manufacturingPlan !== null &&
+      m.manufacturingPlan.year === gameState.year &&
+      m.manufacturingPlan.quarter === gameState.quarter,
+    )
+    .reduce((sum, m) => sum + m.manufacturingPlan!.manufacturing.totalCost, 0);
+
   // Quantity slider: binary search for max affordable
-  const cashForManufacturing = Math.max(0, gameState.cash - totalFixedCosts);
+  const cashForManufacturing = Math.max(0, gameState.cash - totalFixedCosts - otherPlansCost);
   const minPerUnit = calculateBomUnitCost(baseBom, 10_000_000) + ASSEMBLY_QA_COST + PACKAGING_LOGISTICS_COST;
   const maxQuantity = (() => {
     let lo = MIN_BATCH_SIZE;

--- a/src/renderer/screens/dashboard/AdvanceYearCard.tsx
+++ b/src/renderer/screens/dashboard/AdvanceYearCard.tsx
@@ -159,11 +159,9 @@ export function AdvanceYearCard() {
     // Apply quarterly simulation results
     dispatch({ type: "APPLY_QUARTER_RESULT", result });
 
-    // After Q1: generate and publish laptop reviews
-    if (state.quarter === 1) {
-      const reviews = generateReviews(stateForSim, result);
-      dispatch({ type: "SET_REVIEWS", reviews });
-    }
+    // Generate and publish laptop reviews after every quarter
+    const reviews = generateReviews(stateForSim, result);
+    dispatch({ type: "SET_REVIEWS", reviews });
 
     // Navigate to pre-sim news carousel (handles routing to results internally)
     navigateTo("preSimNews");

--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -216,9 +216,7 @@ function gameReducer(state: GameState, action: GameAction): GameState {
                   ...m,
                   status: "onSale" as const,
                   unitsInStock: newStock,
-                  manufacturingPlan: !discontinued && m.manufacturingPlan
-                    ? { ...m.manufacturingPlan, year: nextYear, quarter: 1 as const, results: undefined }
-                    : null,
+                  manufacturingPlan: null,
                 };
               }
 

--- a/src/renderer/wizard/WizardContext.tsx
+++ b/src/renderer/wizard/WizardContext.tsx
@@ -231,7 +231,7 @@ function wizardReducer(state: WizardState, action: WizardAction): WizardState {
       const result = optimiseForDemographic(action.demographic, action.year, action.quarter);
       return {
         ...state,
-        name: `Optimised (${action.demographic.name})`,
+        name: state.name || `Optimised (${action.demographic.name})`,
         modelType: "brandNew",
         screenSize: result.screenSize,
         components: result.components,

--- a/src/simulation/reviewsAwards.ts
+++ b/src/simulation/reviewsAwards.ts
@@ -382,14 +382,24 @@ function getSentiment(value: number, avg: number): "good" | "neutral" | "bad" {
 }
 
 /**
- * Generate reviews for all laptops on sale after Q1.
+ * Generate reviews for all laptops on sale after each quarter.
  */
 export function generateReviews(state: GameState, q1Result: QuarterSimulationResult): LaptopReview[] {
   const reviews: LaptopReview[] = [];
   const year = state.year;
 
-  // Collect all active laptops (player + competitor) from simulation results
-  const allLaptopIds = q1Result.laptopResults.map((r) => r.laptopId);
+  // Only review models that are not discontinued
+  const activeModelIds = new Set<string>();
+  for (const company of state.companies) {
+    for (const model of company.models) {
+      if (model.status !== "discontinued") activeModelIds.add(model.design.id);
+    }
+  }
+
+  // Collect laptops from simulation results, excluding discontinued models
+  const allLaptopIds = q1Result.laptopResults
+    .map((r) => r.laptopId)
+    .filter((id) => activeModelIds.has(id));
   if (allLaptopIds.length === 0) return reviews;
 
   // Build stat vectors for all laptops

--- a/src/simulation/reviewsAwards.ts
+++ b/src/simulation/reviewsAwards.ts
@@ -384,7 +384,7 @@ function getSentiment(value: number, avg: number): "good" | "neutral" | "bad" {
 /**
  * Generate reviews for all laptops on sale after each quarter.
  */
-export function generateReviews(state: GameState, q1Result: QuarterSimulationResult): LaptopReview[] {
+export function generateReviews(state: GameState, quarterResult: QuarterSimulationResult): LaptopReview[] {
   const reviews: LaptopReview[] = [];
   const year = state.year;
 
@@ -397,7 +397,7 @@ export function generateReviews(state: GameState, q1Result: QuarterSimulationRes
   }
 
   // Collect laptops from simulation results, excluding discontinued models
-  const allLaptopIds = q1Result.laptopResults
+  const allLaptopIds = quarterResult.laptopResults
     .map((r) => r.laptopId)
     .filter((id) => activeModelIds.has(id));
   if (allLaptopIds.length === 0) return reviews;


### PR DESCRIPTION
## Summary

- **#243** — Clear `manufacturingPlan` on year advance instead of forwarding it to the new year. Previously, rolling the plan forward caused `isCurrentQuarterPlan = true` in Year N+1 Q1, triggering `LOAD_PLAN` with last year's quantity.
- **#242** — Subtract other models' current-quarter plan costs from the quantity slider's cash ceiling. Cash is only deducted at simulation time, so without this fix the slider ignored committed orders from other active models.
- **#239** — Preserve the user-set laptop name when the design optimiser runs. Changed `name: \`Optimised (...)\`` to `name: state.name || \`Optimised (...)\`` so a user-typed name survives optimiser runs.
- **#229** — Generate reviews after every quarter, not just Q1. Removed the `if (state.quarter === 1)` guard in `AdvanceYearCard`.
- **#237** — Filter discontinued models from review generation. Added an explicit `status !== "discontinued"` check in `generateReviews` as a defensive guard.

## Test plan

- [ ] Start a new game, design and manufacture a laptop in Year 1. Advance to Year 2 Q1, open the manufacturing wizard — quantity field should be blank (not pre-filled with last year's amount).
- [ ] With two active models, confirm a manufacturing order for Model A, then open the wizard for Model B — the quantity slider ceiling should be reduced by Model A's committed spend.
- [ ] In the design wizard, set a laptop name, then run the design optimiser — the name should remain unchanged.
- [ ] Launch a laptop in Q4, simulate Q4 — reviews should appear for that laptop after Q4 resolves (not just after Q1).
- [ ] Discontinue a model, simulate the next quarter — the discontinued model should not receive new reviews.