### PR TITLE
fix: news system bugs #223 #224 #225 #226

### DIFF
--- a/src/renderer/screens/simulation/PreSimNewsScreen.tsx
+++ b/src/renderer/screens/simulation/PreSimNewsScreen.tsx
@@ -267,7 +267,7 @@ function MarketSnapshot() {
             <span style={{ fontSize: tokens.font.sizeSmall, color: tokens.colors.textMuted, display: "flex", alignItems: "center", gap: 6 }}>
               {s.icon} {s.label}
             </span>
-            <span style={{ fontSize: tokens.font.sizeTitle, fontWeight: 700, color: s.color ?? tokens.colors.text }}>
+            <span style={{ fontSize: tokens.font.sizeTitle, fontWeight: 700, color: tokens.colors.text }}>
               {s.value}
             </span>
           </div>

--- a/src/renderer/screens/simulation/PreSimNewsScreen.tsx
+++ b/src/renderer/screens/simulation/PreSimNewsScreen.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
-import { ChevronLeft, ChevronRight, DollarSign, Newspaper, BarChart3, Package, Star, Users } from "lucide-react";
+import { ChevronLeft, ChevronRight, Newspaper, BarChart3, Package, Star, Users } from "lucide-react";
 import { useGame } from "../../state/GameContext";
 import { getPlayerCompany, modelDisplayName } from "../../state/gameTypes";
 import { useNavigation } from "../../navigation/NavigationContext";
@@ -222,7 +222,6 @@ function NewspaperClipping({ item }: { item: NewsItem }) {
 function MarketSnapshot() {
   const { state } = useGame();
   const player = getPlayerCompany(state);
-  const result = state.lastSimulationResult;
 
   const activeModels = player.models.filter((m) => m.status === "manufacturing" || m.status === "onSale");
   const totalInventory = activeModels.reduce((s, m) => s + m.unitsInStock, 0);
@@ -236,7 +235,6 @@ function MarketSnapshot() {
     { label: "Inventory", value: formatNumber(totalInventory), icon: <BarChart3 size={18} /> },
     { label: "Competitors", value: String(competitorCount), icon: <Users size={18} /> },
     { label: "Competing Models", value: String(competitorModels), icon: <Star size={18} /> },
-    { label: "Cash", value: formatCash(result?.cashAfterResolution ?? state.cash), color: tokens.colors.statusCash, icon: <DollarSign size={18} /> },
   ];
 
   return (

--- a/src/renderer/screens/simulation/SimTickerScreen.tsx
+++ b/src/renderer/screens/simulation/SimTickerScreen.tsx
@@ -34,7 +34,7 @@ function aggregateLaptopResults(quarters: QuarterSimulationResult[]): LaptopSale
 }
 
 const DURATION_MS = 12_000;
-const TOAST_DISPLAY_MS = 4_500;
+const TOAST_DISPLAY_MS = 7_500;
 const TOAST_EXIT_MS = 500;
 
 /** Ease-out cubic: fast start, slow finish. */

--- a/src/simulation/newsEngine.ts
+++ b/src/simulation/newsEngine.ts
@@ -302,12 +302,15 @@ export function generateQuarterNews(
   } else if (newComponents.length > 1) {
     // One consolidated article listing all parts, grouped by slot in the subheadline
     const outlet = pickOutlet();
+    const componentsWithLabels = newComponents.map((c) => ({
+      ...c,
+      slotLabel: SLOT_CONFIGS.find((s) => s.slot === c.slot)?.name ?? c.slot,
+    }));
     const bySlot = new Map<string, string[]>();
-    for (const c of newComponents) {
-      const slotLabel = SLOT_CONFIGS.find((s) => s.slot === c.slot)?.name ?? c.slot;
-      const list = bySlot.get(slotLabel) ?? [];
+    for (const c of componentsWithLabels) {
+      const list = bySlot.get(c.slotLabel) ?? [];
       list.push(c.name);
-      bySlot.set(slotLabel, list);
+      bySlot.set(c.slotLabel, list);
     }
     const slotKeys = Array.from(bySlot.keys());
     const primarySlot = slotKeys.length === 1 ? slotKeys[0] : "hardware";
@@ -324,9 +327,9 @@ export function generateQuarterNews(
       subheadline,
       body: {
         type: "componentLaunch",
-        components: newComponents.map((c) => ({
+        components: componentsWithLabels.map((c) => ({
           name: c.name,
-          slot: SLOT_CONFIGS.find((s) => s.slot === c.slot)?.name ?? c.slot,
+          slot: c.slotLabel,
           description: c.description,
         })),
       },

--- a/src/simulation/newsEngine.ts
+++ b/src/simulation/newsEngine.ts
@@ -9,7 +9,7 @@
 
 import { DEMOGRAPHICS } from "../data/demographics";
 import { CompetitorArchetype } from "../data/competitors";
-import { ComponentSlot, DemographicId } from "../data/types";
+import { DemographicId } from "../data/types";
 import { ALL_COMPONENTS } from "../data/components";
 import { SLOT_CONFIGS } from "../data/slotConfigs";
 import { GameState, getPlayerCompany, Quarter, Milestone } from "../renderer/state/gameTypes";
@@ -231,20 +231,21 @@ export function generateQuarterNews(
 
     for (const company of state.companies) {
       if (company.isPlayer) continue;
-      for (const model of company.models) {
-        if (model.yearDesigned !== year) continue;
-        if (reportedCompetitorModels.has(model.design.name)) continue;
-
-        const archetype = company.archetype ?? "generalist";
-        const segment = ARCHETYPE_SEGMENT[archetype];
-        const quotePool = COMPETITOR_PRESS_QUOTES[archetype];
-        const competitorQuotes = shuffled(quotePool).slice(0, 2);
-        items.push(makeProductLaunchItem(
-          makeId(), year, quarter, company.name,
-          model.design.name, model.design.screenSize, model.retailPrice ?? 0,
-          segment, false, competitorQuotes,
-        ));
-      }
+      // Pick at most one model per competitor — the highest-priced new model this year
+      const newModels = company.models
+        .filter((m) => m.yearDesigned === year && !reportedCompetitorModels.has(m.design.name))
+        .sort((a, b) => (b.retailPrice ?? 0) - (a.retailPrice ?? 0));
+      if (newModels.length === 0) continue;
+      const model = newModels[0];
+      const archetype = company.archetype ?? "generalist";
+      const segment = ARCHETYPE_SEGMENT[archetype];
+      const quotePool = COMPETITOR_PRESS_QUOTES[archetype];
+      const competitorQuotes = shuffled(quotePool).slice(0, 2);
+      items.push(makeProductLaunchItem(
+        makeId(), year, quarter, company.name,
+        model.design.name, model.design.screenSize, model.retailPrice ?? 0,
+        segment, false, competitorQuotes,
+      ));
     }
   }
 
@@ -281,51 +282,55 @@ export function generateQuarterNews(
     (c) => c.yearIntroduced === year && (c.quarterIntroduced ?? 1) === quarter,
   );
 
-  if (newComponents.length > 0) {
-    // Group by slot for cleaner headlines
-    const bySlot = new Map<ComponentSlot, typeof newComponents>();
+  if (newComponents.length === 1) {
+    const comp = newComponents[0];
+    const outlet = pickOutlet();
+    const slotLabel = SLOT_CONFIGS.find((s) => s.slot === comp.slot)?.name ?? comp.slot;
+    items.push({
+      id: makeId(),
+      year,
+      quarter,
+      category: "componentLaunch",
+      outlet,
+      headline: generateHeadline(COMPONENT_LAUNCH_TEMPLATES, outlet, { component: comp.name, slot: slotLabel }),
+      subheadline: comp.description,
+      body: {
+        type: "componentLaunch",
+        components: [{ name: comp.name, slot: slotLabel, description: comp.description }],
+      },
+    });
+  } else if (newComponents.length > 1) {
+    // One consolidated article listing all parts, grouped by slot in the subheadline
+    const outlet = pickOutlet();
+    const bySlot = new Map<string, string[]>();
     for (const c of newComponents) {
-      const list = bySlot.get(c.slot) ?? [];
-      list.push(c);
-      bySlot.set(c.slot, list);
+      const slotLabel = SLOT_CONFIGS.find((s) => s.slot === c.slot)?.name ?? c.slot;
+      const list = bySlot.get(slotLabel) ?? [];
+      list.push(c.name);
+      bySlot.set(slotLabel, list);
     }
-
-    for (const [slot, components] of bySlot) {
-      const outlet = pickOutlet();
-      const slotLabel = SLOT_CONFIGS.find((s) => s.slot === slot)?.name ?? slot;
-
-      if (components.length === 1) {
-        const comp = components[0];
-        const vars = { component: comp.name, slot: slotLabel };
-        items.push({
-          id: makeId(),
-          year,
-          quarter,
-          category: "componentLaunch",
-          outlet,
-          headline: generateHeadline(COMPONENT_LAUNCH_TEMPLATES, outlet, vars),
-          subheadline: comp.description,
-          body: {
-            type: "componentLaunch",
-            components: [{ name: comp.name, slot: slotLabel, description: comp.description }],
-          },
-        });
-      } else {
-        const vars = { count: components.length, slot: slotLabel };
-        items.push({
-          id: makeId(),
-          year,
-          quarter,
-          category: "componentLaunch",
-          outlet,
-          headline: generateHeadline(COMPONENT_LAUNCH_MULTI_TEMPLATES, outlet, vars),
-          body: {
-            type: "componentLaunch",
-            components: components.map((c) => ({ name: c.name, slot: slotLabel, description: c.description })),
-          },
-        });
-      }
-    }
+    const slotKeys = Array.from(bySlot.keys());
+    const primarySlot = slotKeys.length === 1 ? slotKeys[0] : "hardware";
+    const subheadline = slotKeys
+      .map((slot) => `${slot}: ${bySlot.get(slot)!.join(", ")}`)
+      .join(" · ");
+    items.push({
+      id: makeId(),
+      year,
+      quarter,
+      category: "componentLaunch",
+      outlet,
+      headline: generateHeadline(COMPONENT_LAUNCH_MULTI_TEMPLATES, outlet, { count: newComponents.length, slot: primarySlot }),
+      subheadline,
+      body: {
+        type: "componentLaunch",
+        components: newComponents.map((c) => ({
+          name: c.name,
+          slot: SLOT_CONFIGS.find((s) => s.slot === c.slot)?.name ?? c.slot,
+          description: c.description,
+        })),
+      },
+    });
   }
 
   return items;


### PR DESCRIPTION
## Summary

- **#224** — Removed `Cash` stat from `MarketSnapshot` in `PreSimNewsScreen.tsx` (post-sim value was spoiling results)
- **#223** — Increased `TOAST_DISPLAY_MS` from 4 500ms → 7 500ms in `SimTickerScreen.tsx`; animation duration unchanged at 12s
- **#225** — Competitor product launches now capped at one item per competitor per quarter (picks the highest-priced new model when a competitor has multiple)
- **#226** — Component launch news consolidated into one article per quarter instead of one per slot; single-component items already named the part correctly; multi-component items now include a subheadline listing all parts grouped by category (e.g. `CPU: Intel Pentium III 1.0 GHz, Intel Celeron 600 MHz · GPU: GeForce2 MX`)

## What was NOT changed

- No news template copy was modified
- No screens outside the simulation flow were touched
- No manufacturing, review, or other systems were touched

## Test plan

- [ ] Pre-sim MarketSnapshot shows no Cash field
- [ ] Headline toasts in SimTicker are readable without pausing
- [ ] Q1 pre-sim news shows at most one article per competitor
- [ ] Q1 with multiple component launches produces one component news article whose subheadline names all launched parts by category
- [ ] Quarter with a single component launch names the part in the headline

Closes #223, #224, #225, #226