### PR TITLE
fix: press release persistence and campaign card stat mismatch (#246, #234)

### DIFF
--- a/src/renderer/manufacturing/ManufacturingWizardContext.tsx
+++ b/src/renderer/manufacturing/ManufacturingWizardContext.tsx
@@ -3,7 +3,7 @@ import { ManufacturingWizardState, ManufacturingWizardStep, MFG_WIZARD_STEPS, Fu
 import { DEMAND_NOISE_MIN, DEMAND_NOISE_MAX, DEFAULT_PRICE_MULTIPLIER, MIN_RETAIL_PRICE, snapPrice, getBaseCostPerUnit } from "./utils/constants";
 
 type MfgWizardAction =
-  | { type: "INIT"; modelId: string; promptIds: number[]; baseBomCost: number; isAdditionalOrder?: boolean; existingRetailPrice?: number }
+  | { type: "INIT"; modelId: string; promptIds: number[]; baseBomCost: number; isAdditionalOrder?: boolean; existingRetailPrice?: number; existingResponses?: Record<number, string> }
   | { type: "LOAD_PLAN"; modelId: string; plan: FullManufacturingPlan; isAdditionalOrder?: boolean }
   | { type: "SET_UNIT_PRICE"; unitPrice: number }
   | { type: "SET_UNITS_ORDERED"; unitsOrdered: number }
@@ -37,6 +37,7 @@ function mfgWizardReducer(state: ManufacturingWizardState, action: MfgWizardActi
         modelId: action.modelId,
         unitPrice: defaultPrice,
         pressReleasePromptIds: action.promptIds,
+        pressReleaseResponses: action.existingResponses ? { ...action.existingResponses } : {},
         noiseMargin: generateNoiseMargin(),
         isAdditionalOrder: action.isAdditionalOrder ?? false,
       };

--- a/src/renderer/screens/BrandDetailScreen.tsx
+++ b/src/renderer/screens/BrandDetailScreen.tsx
@@ -140,6 +140,9 @@ function CampaignCard({
         <span style={{ color: tokens.colors.textMuted }}>
           Pool: <span style={{ color: tokens.colors.text, fontWeight: 600 }}>{poolSize.toLocaleString()}</span>
         </span>
+        <span style={{ color: tokens.colors.textMuted }}>
+          <span style={{ color: tokens.colors.text, fontWeight: 600 }}>{TIER_ACQUISITIONS[campaign.tier].toLocaleString()}</span> acq/qtr
+        </span>
       </div>
 
       {/* Spillover demographics */}

--- a/src/renderer/screens/BrandDetailScreen.tsx
+++ b/src/renderer/screens/BrandDetailScreen.tsx
@@ -141,7 +141,7 @@ function CampaignCard({
           Pool: <span style={{ color: tokens.colors.text, fontWeight: 600 }}>{poolSize.toLocaleString()}</span>
         </span>
         <span style={{ color: tokens.colors.textMuted }}>
-          <span style={{ color: tokens.colors.text, fontWeight: 600 }}>{TIER_ACQUISITIONS[campaign.tier].toLocaleString()}</span> acq/qtr
+          <span style={{ color: tokens.colors.text, fontWeight: 600 }}>{TIER_ACQUISITIONS[campaign.tier].toLocaleString()}</span> acquisitions/qtr
         </span>
       </div>
 

--- a/src/renderer/screens/ModelManagementScreen.tsx
+++ b/src/renderer/screens/ModelManagementScreen.tsx
@@ -99,6 +99,7 @@ export function ModelManagementScreen() {
         baseBomCost: model.design.unitCost,
         isAdditionalOrder: hasPriorOrder,
         existingRetailPrice: model.retailPrice ?? undefined,
+        existingResponses: model.pressReleaseResponses,
       });
     }
     navigateTo("manufacturingWizard");

--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -286,6 +286,7 @@ function gameReducer(state: GameState, action: GameAction): GameState {
               manufacturingQuantity: action.plan.manufacturing.unitsOrdered,
               totalProductionSpend: (m.totalProductionSpend ?? 0) - oldCost + newCost,
               totalUnitsOrdered: (m.totalUnitsOrdered ?? 0) - oldUnits + action.plan.manufacturing.unitsOrdered,
+              pressReleaseResponses: action.plan.pressRelease.responses,
             };
           }),
         ),

--- a/src/renderer/state/gameTypes.ts
+++ b/src/renderer/state/gameTypes.ts
@@ -54,6 +54,8 @@ export interface LaptopModel {
   totalProductionSpend: number;
   /** Cumulative units ordered across all manufacturing orders. */
   totalUnitsOrdered: number;
+  /** Player-authored press release responses — persists for the model's lifetime. */
+  pressReleaseResponses?: Record<number, string>;
 }
 
 /** Returns true if any component in the design has been discontinued by the given year. */

--- a/src/simulation/newsEngine.ts
+++ b/src/simulation/newsEngine.ts
@@ -150,7 +150,7 @@ export function generateQuarterNews(
     if (ms.type === "model") {
       const model = player.models.find((m) => m.design.id === ms.modelId);
       if (!model) continue;
-      const responses = model.manufacturingPlan?.pressRelease?.responses;
+      const responses = model.pressReleaseResponses;
       const pressQuotes = responses ? Object.values(responses).filter((s) => s.length > 0) : undefined;
       items.push(makeProductLaunchItem(
         makeId(), year, quarter, player.name,


### PR DESCRIPTION
## Summary

- **#246** — Move press release responses off `manufacturingPlan` and onto `LaptopModel.pressReleaseResponses`. Previously, responses were read from `model.manufacturingPlan?.pressRelease?.responses`, which is nulled on year advance — causing responses to vanish from milestone news items after Q4. Now stored directly on the model and survive year advance automatically.
- **#234** — Add `acquisitions/qtr` stat to `CampaignCard`'s reach/pool row to match the same stat shown in `AddCampaignPanel`'s preview.

## Changes

**#246 — 5 files:**
- `gameTypes.ts` — `pressReleaseResponses?: Record<number, string>` added to `LaptopModel`
- `GameContext.tsx` — `SET_MANUFACTURING_PLAN` handler now writes `pressReleaseResponses` from the plan onto the model
- `newsEngine.ts:153` — reads `model.pressReleaseResponses` instead of `model.manufacturingPlan?.pressRelease?.responses`
- `ManufacturingWizardContext.tsx` — `INIT` action accepts optional `existingResponses` and pre-fills `pressReleaseResponses` from it
- `ModelManagementScreen.tsx` — passes `existingResponses: model.pressReleaseResponses` in the `INIT` dispatch for additional orders

**#234 — 1 file:**
- `BrandDetailScreen.tsx` — `CampaignCard` reach/pool row gains a third span: `{TIER_ACQUISITIONS[campaign.tier].toLocaleString()} acq/qtr`

## Test plan

- [ ] Complete manufacturing wizard for a new model — confirm press release responses appear in the milestone news article at launch
- [ ] Advance the year, then trigger a milestone news item for the same model — confirm press release quotes still appear (not lost on year advance)
- [ ] Open manufacturing wizard for an additional order — confirm press release responses are pre-filled from the prior order
- [ ] Marketing screen: add a campaign and confirm the `CampaignCard` now shows `acq/qtr` matching the value shown in `AddCampaignPanel` before adding