### PR TITLE
feat: align simulation flow UI with PR #193 mockup

### DIFF
--- a/src/renderer/screens/simulation/PreSimNewsScreen.tsx
+++ b/src/renderer/screens/simulation/PreSimNewsScreen.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
-import { ChevronLeft, ChevronRight, Newspaper, BarChart3, Package, Star, Users } from "lucide-react";
+import { ChevronLeft, ChevronRight, Newspaper, BarChart3, Package, Star, Users, TrendingUp, Calendar, DollarSign, Megaphone } from "lucide-react";
 import { useGame } from "../../state/GameContext";
 import { getPlayerCompany, modelDisplayName } from "../../state/gameTypes";
 import { useNavigation } from "../../navigation/NavigationContext";
@@ -11,9 +11,31 @@ import { reviewScoreColor } from "../../utils/reviewScoreColor";
 
 const CLIPPING_MAX_WIDTH = 680;
 
+// ─── Helpers ────────────────────────────────────────────────
+
+const QUARTER_PUB_DATES = ["January 3", "April 2", "July 1", "October 4"] as const;
+
+function quarterToDate(year: number, quarter: number): string {
+  return `${QUARTER_PUB_DATES[quarter - 1]}, ${year}`;
+}
+
+const SEASONAL_LABELS: [string, string, string, string] = [
+  "Post-Holiday Slowdown",
+  "Spring Recovery",
+  "Back-to-School Season",
+  "Holiday Peak",
+];
+
+function simpleHash(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
 // ─── Outlet Publication Styles ──────────────────────────────
 
-/** Each outlet gets a distinct "newspaper" visual identity. */
 interface PublicationStyle {
   background: string;
   accentColor: string;
@@ -60,6 +82,72 @@ const PUBLICATION_STYLES: Record<NewsOutletId, PublicationStyle> = {
   },
 };
 
+// ─── Editorial Prose Templates ───────────────────────────────
+
+interface EditorialTemplate {
+  paragraphs: string[];
+}
+
+const EDITORIAL_TEMPLATES: Record<NewsOutletId, EditorialTemplate[]> = {
+  techbuzz: [
+    {
+      paragraphs: [
+        "The {modelName} enters a market that's become increasingly competitive over the past few quarters. Buyers are more informed than ever, and {companyName} is banking on a combination of hardware specs and brand credibility to stand out from a crowded field.",
+        "At {price}, the pitch is clear: real performance without the flagship premium. Whether that's enough to move units in volume remains to be seen, but on paper this is a serious contender — and first impressions suggest {companyName} has done its homework.",
+        "Availability is live now at major retailers. Demand forecasts look encouraging, but inventory will be the key variable. Models in this segment often sell faster than manufacturers expect.",
+      ],
+    },
+    {
+      paragraphs: [
+        "{companyName} isn't playing it safe with the {modelName}. The company is swinging hard at a segment it sees as underserved, and with a {screenSize}\" screen and {price} price tag, it's putting real skin in the game.",
+        "The competitive landscape has shifted significantly in recent quarters. Buyers have more options, and the bar for what counts as 'good enough' keeps rising. {companyName}'s answer seems to be specificity — carving out a niche rather than trying to be everything to everyone.",
+        "Launch-day sales will be the first real test. Early signals from retail partners are cautiously optimistic. The brand has goodwill to spend — the question is whether the product can convert interest into purchases.",
+      ],
+    },
+  ],
+  siliconStandard: [
+    {
+      paragraphs: [
+        "The announcement of the {modelName} is a calculated move in what has become a fiercely contested market segment. {companyName} enters with a clear value proposition — {price} for a {screenSize}\" form factor — and a strategy that appears designed around volume more than margin.",
+        "The competitive context matters here. Pricing pressure across the category has been building for several quarters, and {companyName}'s decision to launch at this price point suggests the company believes it can absorb the margin compression while gaining share.",
+        "Longer term, the model's performance will hinge on inventory management and demand conversion. Launch-quarter economics are rarely representative of a product's full lifecycle, but they set important precedents for how the market perceives a brand's pricing strategy.",
+      ],
+    },
+    {
+      paragraphs: [
+        "{companyName} has been measured in its product launches, and the {modelName} continues that pattern. A {screenSize}\" device at {price} is a defensible position in this market — not aggressive, but not timid either.",
+        "From a competitive standpoint, the launch timing is interesting. The segment this product targets has seen steady demand, with buyers generally prioritising value-for-money over headline specifications. {companyName} appears to have calibrated accordingly.",
+        "Analysts will be watching sell-through rates closely over the first two quarters. If the {modelName} performs to category averages, it validates the company's pricing thesis. Outperformance would suggest there's room to push further.",
+      ],
+    },
+  ],
+  consumerWeekly: [
+    {
+      paragraphs: [
+        "If you've been waiting for a laptop that doesn't ask you to choose between price and practicality, the {modelName} might be worth a look. {companyName} has kept things sensible — {screenSize}\" screen, {price} price tag — and the result is a machine built for real-world use rather than benchmark bragging.",
+        "The competition isn't standing still, but {companyName} has thought carefully about who this laptop is for. It's not trying to win every spec sheet comparison. It's trying to make sense to the person buying it.",
+        "It's available now if you want to get your hands on one. We'd recommend checking stock at your local retailer — models like this tend to move faster than the release-day buzz suggests.",
+      ],
+    },
+    {
+      paragraphs: [
+        "Here's a simple way to think about the {modelName}: {companyName} made a laptop for people who need it to work, not just look impressive on spec sheets. At {price} for a {screenSize}\" screen, it's a credible option.",
+        "The feature set is tuned for everyday use rather than edge cases. That's a deliberate call, and honestly it's the right one for most buyers who spend their days doing normal things with their laptops.",
+        "Should you buy it? That depends on your needs — and your current laptop. But for a first look, this one earns a serious second look. Keep an eye on reviews as they roll in over the coming weeks.",
+      ],
+    },
+  ],
+};
+
+function getEditorialTemplate(outlet: NewsOutletId, modelName: string): EditorialTemplate {
+  const pool = EDITORIAL_TEMPLATES[outlet];
+  return pool[simpleHash(modelName) % pool.length];
+}
+
+function interpolateEditorial(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, k) => vars[k] ?? "");
+}
+
 // ─── Clipping Styles ────────────────────────────────────────
 
 function clippingContainerStyle(pub: PublicationStyle): CSSProperties {
@@ -101,16 +189,53 @@ function headlineTextStyle(pub: PublicationStyle): CSSProperties {
   };
 }
 
+// ─── Drop Cap ────────────────────────────────────────────────
+
+function DropCapParagraph({ text, pub, style }: { text: string; pub: PublicationStyle; style?: CSSProperties }) {
+  if (!text) return null;
+  const first = text[0];
+  const rest = text.slice(1);
+  return (
+    <p style={{ margin: 0, fontSize: tokens.font.sizeBase, lineHeight: 1.6, color: pub.textColor, ...style }}>
+      <span style={{
+        float: "left",
+        fontSize: 78,
+        fontFamily: "Georgia, 'Times New Roman', serif",
+        lineHeight: 0.75,
+        marginRight: 6,
+        marginTop: 4,
+        color: pub.accentColor,
+        fontWeight: 700,
+      }}>
+        {first}
+      </span>
+      {rest}
+    </p>
+  );
+}
+
 // ─── Body Renderers ─────────────────────────────────────────
 
-function LaunchBody({ body, pub }: { body: Extract<NewsBody, { type: "productLaunch" }>; pub: PublicationStyle }) {
+function LaunchBody({ item, pub }: { item: NewsItem; pub: PublicationStyle }) {
+  const body = item.body as Extract<NewsBody, { type: "productLaunch" }>;
+  const tmpl = getEditorialTemplate(item.outlet, body.modelName);
+  const vars: Record<string, string> = {
+    companyName: body.companyName,
+    modelName: body.modelName,
+    screenSize: String(body.screenSize),
+    price: formatCash(body.price),
+  };
+
   return (
     <div style={{ marginTop: tokens.spacing.md }}>
+      {/* Specs row */}
       <div style={{ display: "flex", gap: tokens.spacing.xl, flexWrap: "wrap", marginBottom: tokens.spacing.sm }}>
         <Spec label="Screen" value={`${body.screenSize}"`} pub={pub} />
         <Spec label="Price" value={formatCash(body.price)} pub={pub} />
         <Spec label="By" value={body.companyName} pub={pub} />
       </div>
+
+      {/* Press quote */}
       {body.pressQuotes && body.pressQuotes.length > 0 && (
         <div style={{ borderLeft: `3px solid ${pub.accentColor}`, paddingLeft: tokens.spacing.md, marginTop: tokens.spacing.md }}>
           {body.pressQuotes.map((q, i) => (
@@ -120,6 +245,139 @@ function LaunchBody({ body, pub }: { body: Extract<NewsBody, { type: "productLau
           ))}
         </div>
       )}
+
+      {/* Editorial prose */}
+      <div style={{ marginTop: tokens.spacing.lg, display: "flex", flexDirection: "column", gap: tokens.spacing.md }}>
+        {tmpl.paragraphs.map((para, i) => {
+          const text = interpolateEditorial(para, vars);
+          if (i === 0) {
+            return <DropCapParagraph key={i} text={text} pub={pub} />;
+          }
+          return (
+            <p key={i} style={{ margin: 0, fontSize: tokens.font.sizeBase, lineHeight: 1.6, color: pub.textColor }}>
+              {text}
+            </p>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Per-category scores for magazine review ─────────────────
+
+const REVIEW_CATEGORIES = [
+  { key: "performance", label: "Performance" },
+  { key: "display", label: "Display" },
+  { key: "buildQuality", label: "Build Quality" },
+  { key: "battery", label: "Battery" },
+  { key: "value", label: "Value" },
+] as const;
+
+function deriveCategoryScore(base: number, hash: number, shift: number): number {
+  const variance = ((hash >> shift) & 0xf) - 7;
+  return Math.max(1, Math.min(10, base + Math.round(variance * 0.35)));
+}
+
+// ─── Pros/cons extraction ────────────────────────────────────
+
+const POS_KEYWORDS = ["impressive", "excellent", "outstanding", "strong", "highlight", "generous", "top-notch", "best", "crisp", "vibrant", "solid", "great", "clear", "easily", "well", "fast", "fastest", "comfortable"];
+const NEG_KEYWORDS = ["disappointing", "weak", "limited", "below par", "falls short", "struggle", "frustration", "sparse", "dated", "not", "lacking", "slow", "lags", "barely", "tethered", "washed-out"];
+
+function classifySentences(sentences: string[]): { pros: string[]; cons: string[] } {
+  const pros: string[] = [];
+  const cons: string[] = [];
+  for (const s of sentences) {
+    const lower = s.toLowerCase();
+    const isNeg = NEG_KEYWORDS.some((k) => lower.includes(k));
+    const isPos = POS_KEYWORDS.some((k) => lower.includes(k));
+    if (isNeg && !isPos) {
+      cons.push(s);
+    } else {
+      pros.push(s);
+    }
+  }
+  return { pros, cons };
+}
+
+// ─── Magazine Review (consumerWeekly only) ───────────────────
+
+function MagazineReviewBody({ body, pub }: { body: Extract<NewsBody, { type: "review" }>; pub: PublicationStyle }) {
+  const scoreColor = reviewScoreColor(body.score);
+  const hash = simpleHash(body.laptopName);
+  const categoryScores = REVIEW_CATEGORIES.map((cat, i) => ({
+    label: cat.label,
+    score: deriveCategoryScore(body.score, hash, i * 4),
+  }));
+  const { pros, cons } = classifySentences(body.sentences);
+
+  return (
+    <div style={{ marginTop: tokens.spacing.md }}>
+      {/* Score + laptop name */}
+      <div style={{ display: "flex", alignItems: "center", gap: tokens.spacing.lg, marginBottom: tokens.spacing.lg }}>
+        <div style={{
+          width: 72, height: 72, borderRadius: "50%", background: scoreColor, flexShrink: 0,
+          display: "flex", alignItems: "center", justifyContent: "center",
+          fontSize: 28, fontWeight: 700, color: "#fff",
+        }}>
+          {body.score}
+        </div>
+        <div>
+          <div style={{ fontSize: tokens.font.sizeLarge, fontWeight: 700, color: pub.headlineColor, lineHeight: 1.2 }}>
+            {body.laptopName}
+          </div>
+          <div style={{ fontSize: tokens.font.sizeSmall, color: pub.mutedColor, marginTop: 2 }}>
+            Reviewed by {body.outlet}
+          </div>
+        </div>
+      </div>
+
+      {/* Per-category rating bars */}
+      <div style={{ display: "flex", flexDirection: "column", gap: tokens.spacing.sm, marginBottom: tokens.spacing.lg }}>
+        {categoryScores.map(({ label, score }) => (
+          <div key={label} style={{ display: "flex", alignItems: "center", gap: tokens.spacing.md }}>
+            <span style={{ fontSize: tokens.font.sizeSmall, color: pub.mutedColor, width: 90, flexShrink: 0 }}>
+              {label}
+            </span>
+            <div style={{ flex: 1, height: 8, background: pub.borderColor, borderRadius: 4, overflow: "hidden" }}>
+              <div style={{
+                height: "100%",
+                width: `${score * 10}%`,
+                background: reviewScoreColor(score),
+                borderRadius: 4,
+              }} />
+            </div>
+            <span style={{ fontSize: tokens.font.sizeSmall, color: pub.headlineColor, fontWeight: 600, width: 20, textAlign: "right", flexShrink: 0 }}>
+              {score}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Pros / cons */}
+      <div style={{ display: "flex", gap: tokens.spacing.lg, borderTop: `1px solid ${pub.borderColor}`, paddingTop: tokens.spacing.md }}>
+        {pros.length > 0 && (
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: tokens.font.sizeSmall, fontWeight: 700, color: "#2e7d32", textTransform: "uppercase", letterSpacing: 0.6, marginBottom: tokens.spacing.xs }}>
+              Verdict
+            </div>
+            {pros.slice(0, 2).map((s, i) => {
+              if (i === 0) return <DropCapParagraph key={i} text={s} pub={pub} style={{ marginBottom: tokens.spacing.xs }} />;
+              return <p key={i} style={{ margin: 0, fontSize: tokens.font.sizeBase, lineHeight: 1.5, color: pub.mutedColor }}>{s}</p>;
+            })}
+          </div>
+        )}
+        {cons.length > 0 && (
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: tokens.font.sizeSmall, fontWeight: 700, color: "#c62828", textTransform: "uppercase", letterSpacing: 0.6, marginBottom: tokens.spacing.xs }}>
+              Watch Out For
+            </div>
+            {cons.slice(0, 2).map((s, i) => (
+              <p key={i} style={{ margin: i > 0 ? `${tokens.spacing.xs}px 0 0` : 0, fontSize: tokens.font.sizeBase, lineHeight: 1.5, color: pub.mutedColor }}>{s}</p>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -143,11 +401,14 @@ function ReviewClippingBody({ body, pub }: { body: Extract<NewsBody, { type: "re
       </div>
       {body.sentences.length > 0 && (
         <div style={{ borderTop: `1px solid ${pub.borderColor}`, paddingTop: tokens.spacing.sm }}>
-          {body.sentences.map((s, i) => (
-            <p key={i} style={{ color: pub.mutedColor, margin: i > 0 ? `${tokens.spacing.xs}px 0 0` : 0, fontSize: tokens.font.sizeBase, lineHeight: 1.5 }}>
-              {s}
-            </p>
-          ))}
+          {body.sentences.map((s, i) => {
+            if (i === 0) return <DropCapParagraph key={i} text={s} pub={pub} style={{ marginBottom: tokens.spacing.xs }} />;
+            return (
+              <p key={i} style={{ color: pub.mutedColor, margin: `${tokens.spacing.xs}px 0 0`, fontSize: tokens.font.sizeBase, lineHeight: 1.5 }}>
+                {s}
+              </p>
+            );
+          })}
         </div>
       )}
     </div>
@@ -167,8 +428,11 @@ function GenericBody({ item, pub }: { item: NewsItem; pub: PublicationStyle }) {
   if (!item.body) return null;
   switch (item.body.type) {
     case "productLaunch":
-      return <LaunchBody body={item.body} pub={pub} />;
+      return <LaunchBody item={item} pub={pub} />;
     case "review":
+      if (item.outlet === "consumerWeekly") {
+        return <MagazineReviewBody body={item.body} pub={pub} />;
+      }
       return <ReviewClippingBody body={item.body} pub={pub} />;
     default:
       return null;
@@ -202,7 +466,7 @@ function NewspaperClipping({ item }: { item: NewsItem }) {
       <div style={mastheadStyle(pub)}>
         <span>{outlet.name}</span>
         <span style={{ fontSize: tokens.font.sizeSmall, fontWeight: 400, color: pub.mutedColor }}>
-          Q{item.quarter} {item.year}
+          {quarterToDate(item.year, item.quarter)}
         </span>
       </div>
       <CategoryBadge category={item.category} pub={pub} />
@@ -222,19 +486,39 @@ function NewspaperClipping({ item }: { item: NewsItem }) {
 function MarketSnapshot() {
   const { state } = useGame();
   const player = getPlayerCompany(state);
+  const result = state.lastSimulationResult;
 
   const activeModels = player.models.filter((m) => m.status === "manufacturing" || m.status === "onSale");
   const totalInventory = activeModels.reduce((s, m) => s + m.unitsInStock, 0);
-  const competitorCount = state.companies.filter((c) => !c.isPlayer).length;
-  const competitorModels = state.companies
-    .filter((c) => !c.isPlayer)
-    .reduce((s, c) => s + c.models.filter((m) => m.unitsInStock > 0 || m.yearDesigned === state.year).length, 0);
+  const activeCampaigns = state.marketingCampaigns.filter((c) => !c.paused).length;
+
+  // Competitor models from this quarter's results
+  const competitorResults = result
+    ? result.laptopResults.filter((lr) => lr.owner !== player.id && lr.unitsSold > 0)
+    : [];
+  const competingModels = competitorResults.length;
+
+  // Price range of competing models
+  const competitorPrices = competitorResults.map((lr) => lr.retailPrice).filter((p) => p > 0);
+  const priceRangeLabel = competitorPrices.length > 0
+    ? `${formatCash(Math.min(...competitorPrices))} – ${formatCash(Math.max(...competitorPrices))}`
+    : "N/A";
+
+  // Seasonal demand label
+  const seasonalLabel = result ? SEASONAL_LABELS[result.quarter - 1] : SEASONAL_LABELS[state.quarter - 1];
+
+  // Pre-simulation cash (cash before sales resolved)
+  const preSimCash = result
+    ? result.cashAfterResolution - result.totalRevenue + result.marketingCost
+    : state.cash;
 
   const stats = [
-    { label: "Your Models", value: String(activeModels.length), icon: <Package size={18} /> },
-    { label: "Inventory", value: formatNumber(totalInventory), icon: <BarChart3 size={18} /> },
-    { label: "Competitors", value: String(competitorCount), icon: <Users size={18} /> },
-    { label: "Competing Models", value: String(competitorModels), icon: <Star size={18} /> },
+    { label: "Models Competing", value: String(competingModels), icon: <Users size={18} /> },
+    { label: "Price Range", value: priceRangeLabel, icon: <TrendingUp size={18} />, small: true },
+    { label: "Your Inventory", value: formatNumber(totalInventory), icon: <Package size={18} /> },
+    { label: "Seasonal Demand", value: seasonalLabel, icon: <Calendar size={18} />, small: true },
+    { label: "Active Campaigns", value: String(activeCampaigns), icon: <Megaphone size={18} /> },
+    { label: "Cash on Hand", value: formatCash(Math.round(preSimCash)), icon: <DollarSign size={18} />, small: true },
   ];
 
   return (
@@ -251,7 +535,9 @@ function MarketSnapshot() {
         Market Snapshot
       </div>
       <div style={{ fontSize: tokens.font.sizeBase, color: tokens.colors.textMuted, textAlign: "center", marginBottom: tokens.spacing.lg }}>
-        {QUARTER_LABELS[state.quarter - 1]} {state.year} — Here&apos;s where things stand.
+        {result
+          ? `${QUARTER_LABELS[result.quarter - 1]} ${result.year} — Here's where things stand.`
+          : `${QUARTER_LABELS[state.quarter - 1]} ${state.year} — Here's where things stand.`}
       </div>
 
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: tokens.spacing.md }}>
@@ -267,7 +553,12 @@ function MarketSnapshot() {
             <span style={{ fontSize: tokens.font.sizeSmall, color: tokens.colors.textMuted, display: "flex", alignItems: "center", gap: 6 }}>
               {s.icon} {s.label}
             </span>
-            <span style={{ fontSize: tokens.font.sizeTitle, fontWeight: 700, color: tokens.colors.text }}>
+            <span style={{
+              fontSize: s.small ? tokens.font.sizeLarge : tokens.font.sizeTitle,
+              fontWeight: 700,
+              color: tokens.colors.text,
+              lineHeight: 1.2,
+            }}>
               {s.value}
             </span>
           </div>
@@ -336,11 +627,11 @@ function DotIndicator({ count, activeIndex }: { count: number; activeIndex: numb
         <div
           key={i}
           style={{
-            width: i === activeIndex ? 24 : 8,
+            width: 8,
             height: 8,
             borderRadius: 4,
             background: i === activeIndex ? tokens.colors.accent : tokens.colors.surface,
-            transition: "width 0.2s, background 0.2s",
+            transition: "background 0.2s",
           }}
         />
       ))}
@@ -356,7 +647,6 @@ export function PreSimNewsScreen() {
   const result = state.lastSimulationResult;
   const [currentSlide, setCurrentSlide] = useState(0);
 
-  // Collect pre-sim articles for this quarter: product launches + reviews
   const preSimArticles = useMemo(() => {
     if (!result) return [];
     return state.newsHistory.filter(
@@ -367,7 +657,6 @@ export function PreSimNewsScreen() {
     );
   }, [state.newsHistory, result]);
 
-  // Total slides = articles + market snapshot
   const totalSlides = preSimArticles.length + 1;
   const isLastSlide = currentSlide === totalSlides - 1;
 
@@ -379,13 +668,11 @@ export function PreSimNewsScreen() {
     setCurrentSlide((i) => Math.max(i - 1, 0));
   }, []);
 
-  // Navigate to the sim ticker animation
   const proceed = useCallback(() => {
     if (!result) return;
     navigateTo("simTicker");
   }, [result, navigateTo]);
 
-  // Keyboard navigation — skip if a button/link is focused to avoid double-firing
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       const tag = (e.target as HTMLElement).tagName;
@@ -404,7 +691,6 @@ export function PreSimNewsScreen() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [goNext, goPrev, isLastSlide, proceed]);
 
-  // Skip to results if there are no articles (quiet quarter)
   if (preSimArticles.length === 0) {
     return (
       <div style={screenStyle}>
@@ -456,7 +742,6 @@ export function PreSimNewsScreen() {
               <NewspaperClipping item={article} />
             </div>
           ))}
-          {/* Market snapshot = last slide */}
           <div
             style={{
               display: isLastSlide ? "flex" : "none",

--- a/src/renderer/screens/simulation/SimTickerScreen.tsx
+++ b/src/renderer/screens/simulation/SimTickerScreen.tsx
@@ -34,8 +34,6 @@ function aggregateLaptopResults(quarters: QuarterSimulationResult[]): LaptopSale
 }
 
 const DURATION_MS = 12_000;
-const TOAST_DISPLAY_MS = 7_500;
-const TOAST_EXIT_MS = 500;
 
 /** Ease-out cubic: fast start, slow finish. */
 function easeOutCubic(t: number): number {
@@ -159,27 +157,11 @@ const HEADLINE_TYPE_COLOR: Record<TickerHeadline["type"], string> = {
 
 function HeadlineToast({
   headline,
-  onDismiss,
   onClick,
 }: {
   headline: TickerHeadline;
-  onDismiss: () => void;
   onClick: () => void;
 }) {
-  const [exiting, setExiting] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setExiting(true), TOAST_DISPLAY_MS);
-    return () => clearTimeout(timer);
-  }, []);
-
-  useEffect(() => {
-    if (exiting) {
-      const timer = setTimeout(onDismiss, TOAST_EXIT_MS);
-      return () => clearTimeout(timer);
-    }
-  }, [exiting, onDismiss]);
-
   return (
     <div
       onClick={onClick}
@@ -191,7 +173,7 @@ function HeadlineToast({
         padding: `${tokens.spacing.sm}px ${tokens.spacing.md}px`,
         fontSize: tokens.font.sizeBase,
         color: tokens.colors.text,
-        animation: exiting ? "toastSlideOut 0.5s ease-in forwards" : "toastSlideIn 0.4s ease-out",
+        animation: "toastSlideIn 0.4s ease-out",
         cursor: "pointer",
       }}
     >
@@ -423,6 +405,7 @@ export function SimTickerScreen() {
   const startTimeRef = useRef<number | null>(null);
   const pausedAtRef = useRef(0);
   const rafRef = useRef<number>(0);
+  const progressRef = useRef(0);
 
   const headlines = useMemo(() => {
     if (!result) return [];
@@ -470,6 +453,7 @@ export function SimTickerScreen() {
       }
       const elapsed = timestamp - startTimeRef.current;
       const p = Math.min(elapsed / DURATION_MS, 1);
+      progressRef.current = p;
       setProgress(p);
 
       for (let i = 0; i < headlines.length; i++) {
@@ -489,14 +473,6 @@ export function SimTickerScreen() {
     rafRef.current = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafRef.current);
   }, [done, paused, isOverlayOpen, result, headlines]);
-
-  // When overlay closes, reset start time so animation resumes from current position
-  useEffect(() => {
-    if (!isOverlayOpen) {
-      startTimeRef.current = null;
-      pausedAtRef.current = progress * DURATION_MS;
-    }
-  }, [isOverlayOpen, progress]);
 
   const handleSkip = useCallback(() => {
     cancelAnimationFrame(rafRef.current);
@@ -524,6 +500,8 @@ export function SimTickerScreen() {
   }, [progress]);
 
   const closeOverlay = useCallback(() => {
+    pausedAtRef.current = progressRef.current * DURATION_MS;
+    startTimeRef.current = null;
     setOverlayHeadline(null);
   }, []);
 
@@ -682,7 +660,6 @@ export function SimTickerScreen() {
               <HeadlineToast
                 key={h.triggerAt}
                 headline={h}
-                onDismiss={() => setVisibleHeadlines((prev) => prev.filter((x) => x !== h))}
                 onClick={() => openOverlay(h)}
               />
             ))}

--- a/src/renderer/screens/simulation/SimTickerScreen.tsx
+++ b/src/renderer/screens/simulation/SimTickerScreen.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { SkipForward } from "lucide-react";
+import { SkipForward, X } from "lucide-react";
 import { useGame } from "../../state/GameContext";
 import { getPlayerCompany, modelDisplayName } from "../../state/gameTypes";
 import { useNavigation } from "../../navigation/NavigationContext";
@@ -42,6 +42,25 @@ function easeOutCubic(t: number): number {
   return 1 - Math.pow(1 - t, 3);
 }
 
+/** Convert (year, quarter, progress 0–1) to a full calendar date string like "January 22, 2027". */
+function quarterProgressToDate(year: number, quarter: number, progress: number): string {
+  const quarterStartMonths = [0, 3, 6, 9]; // Jan, Apr, Jul, Oct
+  const startMonth = quarterStartMonths[quarter - 1];
+  const startDate = new Date(year, startMonth, 1);
+  const dayOffset = Math.round(progress * 90);
+  const current = new Date(startDate.getTime() + dayOffset * 86_400_000);
+  return current.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+}
+
+// ─── Outlet name by headline type ────────────────────────────
+
+const HEADLINE_OUTLET: Record<TickerHeadline["type"], string> = {
+  milestone: "TechBuzz",
+  sellout: "TechBuzz",
+  trend: "The Silicon Standard",
+  perception: "Consumer Weekly",
+};
+
 // ─── Animated Counter ────────────────────────────────────────
 
 function AnimatedValue({ value, from = 0, progress, format }: { value: number; from?: number; progress: number; format: (n: number) => string }) {
@@ -53,14 +72,16 @@ function AnimatedValue({ value, from = 0, progress, format }: { value: number; f
 
 interface SalesBarProps {
   label: string;
+  retailPrice: number;
   unitsSold: number;
+  capacity: number;
   maxUnits: number;
   unsoldUnits: number;
   progress: number;
   isPlayer: boolean;
 }
 
-function SalesBar({ label, unitsSold, maxUnits, unsoldUnits, progress, isPlayer }: SalesBarProps) {
+function SalesBar({ label, retailPrice, unitsSold, capacity, maxUnits, unsoldUnits, progress, isPlayer }: SalesBarProps) {
   const easedProgress = easeOutCubic(progress);
   const currentUnits = Math.round(unitsSold * easedProgress);
   const pct = maxUnits > 0 ? (unitsSold / maxUnits) * easedProgress * 100 : 0;
@@ -74,23 +95,35 @@ function SalesBar({ label, unitsSold, maxUnits, unsoldUnits, progress, isPlayer 
         alignItems: "baseline",
         marginBottom: 3,
       }}>
-        <span style={{
-          fontSize: tokens.font.sizeBase,
-          fontWeight: isPlayer ? 600 : 400,
-          color: isPlayer ? tokens.colors.text : tokens.colors.textMuted,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-          maxWidth: "70%",
-        }}>
-          {label}
-        </span>
+        <div style={{ display: "flex", alignItems: "baseline", gap: tokens.spacing.sm, minWidth: 0 }}>
+          <span style={{
+            fontSize: tokens.font.sizeBase,
+            fontWeight: isPlayer ? 600 : 400,
+            color: isPlayer ? tokens.colors.text : tokens.colors.textMuted,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}>
+            {label}
+          </span>
+          <span style={{
+            fontSize: tokens.font.sizeSmall,
+            color: tokens.colors.textMuted,
+            whiteSpace: "nowrap",
+            flexShrink: 0,
+          }}>
+            {formatCash(retailPrice)}
+          </span>
+        </div>
         <span style={{
           fontSize: tokens.font.sizeSmall,
           color: tokens.colors.textMuted,
           fontVariantNumeric: "tabular-nums",
+          whiteSpace: "nowrap",
+          flexShrink: 0,
+          marginLeft: tokens.spacing.sm,
         }}>
-          {formatNumber(currentUnits)} units
+          {formatNumber(currentUnits)} / {formatNumber(capacity)} sold
         </span>
       </div>
       <div style={{
@@ -124,7 +157,15 @@ const HEADLINE_TYPE_COLOR: Record<TickerHeadline["type"], string> = {
   perception: tokens.colors.market,
 };
 
-function HeadlineToast({ headline, onDismiss }: { headline: TickerHeadline; onDismiss: () => void }) {
+function HeadlineToast({
+  headline,
+  onDismiss,
+  onClick,
+}: {
+  headline: TickerHeadline;
+  onDismiss: () => void;
+  onClick: () => void;
+}) {
   const [exiting, setExiting] = useState(false);
 
   useEffect(() => {
@@ -140,33 +181,139 @@ function HeadlineToast({ headline, onDismiss }: { headline: TickerHeadline; onDi
   }, [exiting, onDismiss]);
 
   return (
-    <div style={{
-      background: tokens.colors.cardBg,
-      border: `1px solid ${tokens.colors.panelBorder}`,
-      borderLeft: `3px solid ${HEADLINE_TYPE_COLOR[headline.type]}`,
-      borderRadius: tokens.borderRadius.sm,
-      padding: `${tokens.spacing.sm}px ${tokens.spacing.md}px`,
-      fontSize: tokens.font.sizeBase,
-      color: tokens.colors.text,
-      animation: exiting ? "toastSlideOut 0.5s ease-in forwards" : "toastSlideIn 0.4s ease-out",
-      maxWidth: 480,
-    }}>
+    <div
+      onClick={onClick}
+      style={{
+        background: tokens.colors.cardBg,
+        border: `1px solid ${tokens.colors.panelBorder}`,
+        borderLeft: `3px solid ${HEADLINE_TYPE_COLOR[headline.type]}`,
+        borderRadius: tokens.borderRadius.sm,
+        padding: `${tokens.spacing.sm}px ${tokens.spacing.md}px`,
+        fontSize: tokens.font.sizeBase,
+        color: tokens.colors.text,
+        animation: exiting ? "toastSlideOut 0.5s ease-in forwards" : "toastSlideIn 0.4s ease-out",
+        cursor: "pointer",
+      }}
+    >
       {headline.text}
     </div>
   );
 }
 
+// ─── Headline Article Overlay ─────────────────────────────────
+
+function HeadlineOverlay({ headline, onClose }: { headline: TickerHeadline; onClose: () => void }) {
+  return (
+    <div style={{
+      position: "absolute",
+      inset: 0,
+      background: "rgba(0,0,0,0.7)",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      zIndex: 100,
+    }}>
+      <div style={{
+        background: tokens.colors.cardBg,
+        border: `1px solid ${tokens.colors.panelBorder}`,
+        borderRadius: tokens.borderRadius.md,
+        padding: tokens.spacing.xl,
+        maxWidth: 560,
+        width: "90%",
+        position: "relative",
+      }}>
+        {/* Outlet header */}
+        <div style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: tokens.spacing.md,
+        }}>
+          <span style={{
+            fontSize: tokens.font.sizeSmall,
+            fontWeight: 600,
+            color: HEADLINE_TYPE_COLOR[headline.type],
+            textTransform: "uppercase",
+            letterSpacing: 0.8,
+          }}>
+            {HEADLINE_OUTLET[headline.type]}
+          </span>
+          <button
+            onClick={onClose}
+            style={{
+              background: "none",
+              border: "none",
+              color: tokens.colors.textMuted,
+              cursor: "pointer",
+              padding: 4,
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Headline */}
+        <h2 style={{
+          margin: 0,
+          fontSize: tokens.font.sizeLarge,
+          fontWeight: 700,
+          color: tokens.colors.text,
+          lineHeight: 1.35,
+          marginBottom: tokens.spacing.md,
+        }}>
+          {headline.text}
+        </h2>
+
+        {/* Body */}
+        <p style={{
+          margin: 0,
+          fontSize: tokens.font.sizeBase,
+          color: tokens.colors.textMuted,
+          lineHeight: 1.6,
+        }}>
+          {overlayBodyText(headline)}
+        </p>
+
+        <button
+          onClick={onClose}
+          style={{
+            marginTop: tokens.spacing.lg,
+            background: "none",
+            border: `1px solid ${tokens.colors.panelBorder}`,
+            borderRadius: tokens.borderRadius.sm,
+            color: tokens.colors.textMuted,
+            cursor: "pointer",
+            fontSize: tokens.font.sizeSmall,
+            fontFamily: tokens.font.family,
+            padding: `${tokens.spacing.xs}px ${tokens.spacing.md}px`,
+          }}
+        >
+          Close (resume)
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function overlayBodyText(h: TickerHeadline): string {
+  switch (h.type) {
+    case "milestone":
+      return "Sales momentum continues to build as the quarter progresses. Analysts note strong consumer interest and healthy inventory turnover. The numbers tell a compelling story.";
+    case "sellout":
+      return "Demand outpaced supply this quarter. Retailers report empty shelves and frustrated buyers, a clear sign that production targets may need to be revisited heading into next quarter.";
+    case "trend":
+      return "Market data reveals clear winner-take-most dynamics across buyer segments this quarter. Brands that aligned their value proposition with this segment's priorities saw outsized returns.";
+    case "perception":
+      return "Brand sentiment tracking shows a measurable shift in how consumers view the company. Word of mouth, review coverage, and product availability all play a role in shaping perception over time.";
+  }
+}
+
 // ─── Date Progress Bar ───────────────────────────────────────
 
 function DateProgressBar({ progress, quarter, year }: { progress: number; quarter: number; year: number }) {
-  const months = [
-    ["Jan", "Feb", "Mar"],
-    ["Apr", "May", "Jun"],
-    ["Jul", "Aug", "Sep"],
-    ["Oct", "Nov", "Dec"],
-  ];
-  const qMonths = months[quarter - 1];
-  const monthIdx = Math.min(Math.floor(progress * 3), 2);
+  const dateLabel = quarterProgressToDate(year, quarter, progress);
 
   return (
     <div>
@@ -177,8 +324,7 @@ function DateProgressBar({ progress, quarter, year }: { progress: number; quarte
         fontSize: tokens.font.sizeSmall,
         color: tokens.colors.textMuted,
       }}>
-        <span>{QUARTER_LABELS[quarter - 1]} {year}</span>
-        <span>{qMonths[monthIdx]}</span>
+        <span>{dateLabel}</span>
       </div>
       <div style={{
         height: 6,
@@ -198,29 +344,64 @@ function DateProgressBar({ progress, quarter, year }: { progress: number; quarte
   );
 }
 
-// ─── KPI Counter ─────────────────────────────────────────────
+// ─── KPI Strip ────────────────────────────────────────────────
 
-function KpiCounter({ label, value, from, progress, format, color }: {
-  label: string;
-  value: number;
-  from?: number;
+function KpiStrip({ revenue, cash, cashBefore, progress }: {
+  revenue: number;
+  cash: number;
+  cashBefore: number;
   progress: number;
-  format: (n: number) => string;
-  color?: string;
 }) {
   return (
+    <div style={{
+      display: "flex",
+      gap: tokens.spacing.xl,
+      justifyContent: "center",
+      background: tokens.colors.cardBg,
+      border: `1px solid ${tokens.colors.panelBorder}`,
+      borderRadius: tokens.borderRadius.md,
+      padding: `${tokens.spacing.md}px ${tokens.spacing.xl}px`,
+    }}>
+      <KpiItem label="Revenue" color={tokens.colors.success}>
+        <AnimatedValue value={revenue} progress={progress} format={(n) => formatCash(Math.round(n))} />
+      </KpiItem>
+      <KpiItem label="Cash on Hand" color={tokens.colors.statusCash}>
+        <AnimatedValue value={cash} from={cashBefore} progress={progress} format={(n) => formatCash(Math.round(n))} />
+      </KpiItem>
+    </div>
+  );
+}
+
+function KpiItem({ label, color, children }: { label: string; color: string; children: React.ReactNode }) {
+  return (
     <div style={{ textAlign: "center" }}>
-      <div style={{ fontSize: tokens.font.sizeSmall, color: tokens.colors.textMuted, marginBottom: 2 }}>
-        {label}
-      </div>
+      <div style={{ fontSize: tokens.font.sizeSmall, color: tokens.colors.textMuted, marginBottom: 2 }}>{label}</div>
       <div style={{
         fontSize: tokens.font.sizeTitle,
         fontWeight: 700,
         fontVariantNumeric: "tabular-nums",
-        color: color ?? tokens.colors.text,
+        color,
       }}>
-        <AnimatedValue value={value} from={from} progress={progress} format={format} />
+        {children}
       </div>
+    </div>
+  );
+}
+
+// ─── Group Label ──────────────────────────────────────────────
+
+function GroupLabel({ text }: { text: string }) {
+  return (
+    <div style={{
+      fontSize: tokens.font.sizeSmall,
+      fontWeight: 600,
+      color: tokens.colors.textMuted,
+      textTransform: "uppercase",
+      letterSpacing: 0.8,
+      marginBottom: tokens.spacing.sm,
+      marginTop: tokens.spacing.md,
+    }}>
+      {text}
     </div>
   );
 }
@@ -237,6 +418,7 @@ export function SimTickerScreen() {
   const [done, setDone] = useState(false);
   const [paused, setPaused] = useState(false);
   const [visibleHeadlines, setVisibleHeadlines] = useState<TickerHeadline[]>([]);
+  const [overlayHeadline, setOverlayHeadline] = useState<TickerHeadline | null>(null);
   const triggeredRef = useRef(new Set<number>());
   const startTimeRef = useRef<number | null>(null);
   const pausedAtRef = useRef(0);
@@ -248,20 +430,25 @@ export function SimTickerScreen() {
   }, [state, result]);
 
   // All sales results sorted: player first (by units desc), then competitors (by units desc)
-  const sortedResults = useMemo(() => {
+  const sortedPlayerResults = useMemo(() => {
     if (!result) return [];
-    const playerResults = result.playerResults.slice().sort((a, b) => b.unitsSold - a.unitsSold);
-    const compResults = result.laptopResults
+    return result.playerResults.slice().sort((a, b) => b.unitsSold - a.unitsSold);
+  }, [result]);
+
+  const sortedCompResults = useMemo(() => {
+    if (!result) return [];
+    return result.laptopResults
       .filter((lr) => lr.owner !== player.id)
       .sort((a, b) => b.unitsSold - a.unitsSold)
       .slice(0, MAX_COMPETITOR_MODELS);
-    return [...playerResults, ...compResults];
   }, [result, player.id]);
 
+  const allSortedResults = useMemo(() => [...sortedPlayerResults, ...sortedCompResults], [sortedPlayerResults, sortedCompResults]);
+
   const maxUnits = useMemo(() => {
-    if (sortedResults.length === 0) return 1;
-    return Math.max(...sortedResults.map((lr) => lr.unitsSold), 1);
-  }, [sortedResults]);
+    if (allSortedResults.length === 0) return 1;
+    return Math.max(...allSortedResults.map((lr) => lr.unitsSold), 1);
+  }, [allSortedResults]);
 
   const getModelLabel = useCallback((lr: LaptopSalesResult) => {
     const company = state.companies.find((c) => c.id === lr.owner);
@@ -271,9 +458,11 @@ export function SimTickerScreen() {
     return modelDisplayName(company.name, model.design.name);
   }, [state.companies]);
 
-  // RAF animation loop
+  const isOverlayOpen = overlayHeadline !== null;
+
+  // RAF animation loop — paused when overlay is open
   useEffect(() => {
-    if (done || paused || !result) return;
+    if (done || paused || isOverlayOpen || !result) return;
 
     function tick(timestamp: number) {
       if (startTimeRef.current === null) {
@@ -283,7 +472,6 @@ export function SimTickerScreen() {
       const p = Math.min(elapsed / DURATION_MS, 1);
       setProgress(p);
 
-      // Trigger headlines
       for (let i = 0; i < headlines.length; i++) {
         if (p >= headlines[i].triggerAt && !triggeredRef.current.has(i)) {
           triggeredRef.current.add(i);
@@ -300,7 +488,15 @@ export function SimTickerScreen() {
 
     rafRef.current = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafRef.current);
-  }, [done, paused, result, headlines]);
+  }, [done, paused, isOverlayOpen, result, headlines]);
+
+  // When overlay closes, reset start time so animation resumes from current position
+  useEffect(() => {
+    if (!isOverlayOpen) {
+      startTimeRef.current = null;
+      pausedAtRef.current = progress * DURATION_MS;
+    }
+  }, [isOverlayOpen, progress]);
 
   const handleSkip = useCallback(() => {
     cancelAnimationFrame(rafRef.current);
@@ -320,10 +516,20 @@ export function SimTickerScreen() {
     setPaused(false);
   }, []);
 
+  const openOverlay = useCallback((h: TickerHeadline) => {
+    cancelAnimationFrame(rafRef.current);
+    pausedAtRef.current = progress * DURATION_MS;
+    startTimeRef.current = null;
+    setOverlayHeadline(h);
+  }, [progress]);
+
+  const closeOverlay = useCallback(() => {
+    setOverlayHeadline(null);
+  }, []);
+
   const proceed = useCallback(() => {
     if (!result) return;
     if (result.quarter === 4) {
-      // Determine year-end awards after Q4 sales animation completes
       const yearLaptopResults = aggregateLaptopResults(state.quarterHistory);
       const awards = determineAwards(state, yearLaptopResults);
       dispatch({ type: "SET_AWARDS", awards });
@@ -338,9 +544,13 @@ export function SimTickerScreen() {
     }
   }, [result, state, dispatch, navigateTo]);
 
-  // Keyboard: Space to pause/resume, Enter/Escape to skip
+  // Keyboard: Space to pause/resume, Enter/Escape to skip or proceed
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
+      if (isOverlayOpen) {
+        if (e.key === "Escape" || e.key === "Enter") closeOverlay();
+        return;
+      }
       if (e.key === " ") {
         e.preventDefault();
         if (done) {
@@ -360,11 +570,10 @@ export function SimTickerScreen() {
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [done, paused, handlePause, handleResume, handleSkip, proceed]);
+  }, [done, paused, isOverlayOpen, handlePause, handleResume, handleSkip, proceed, closeOverlay]);
 
   if (!result) return null;
 
-  const totalUnits = result.playerResults.reduce((s, lr) => s + lr.unitsSold, 0);
   const cashBefore = result.cashAfterResolution - result.totalRevenue + result.marketingCost;
 
   return (
@@ -401,99 +610,84 @@ export function SimTickerScreen() {
         </div>
       </div>
 
-      {/* Date progress */}
-      <div style={{ padding: `0 ${tokens.spacing.xl}px`, marginBottom: tokens.spacing.lg }}>
+      {/* Centered single column */}
+      <div style={columnStyle}>
+        {/* Date progress */}
         <DateProgressBar progress={progress} quarter={result.quarter} year={result.year} />
-      </div>
 
-      {/* Main content: sales bars + KPIs */}
-      <div style={contentAreaStyle}>
-        {/* Left: Sales bars */}
-        <div style={{ flex: 1, minWidth: 0, overflow: "auto" }}>
-          <div style={{
-            fontSize: tokens.font.sizeBase,
-            fontWeight: 600,
-            marginBottom: tokens.spacing.md,
-            color: tokens.colors.text,
-          }}>
-            Sales
-          </div>
-          {sortedResults.map((lr) => (
-            <SalesBar
-              key={lr.laptopId}
-              label={getModelLabel(lr)}
-              unitsSold={lr.unitsSold}
-              maxUnits={maxUnits}
-              unsoldUnits={lr.unsoldUnits}
-              progress={progress}
-              isPlayer={lr.owner === player.id}
-            />
-          ))}
-          {sortedResults.length === 0 && (
+        {/* Sales bars */}
+        <div style={{ marginTop: tokens.spacing.lg }}>
+          {sortedPlayerResults.length > 0 && (
+            <>
+              <GroupLabel text="Your Models" />
+              {sortedPlayerResults.map((lr) => (
+                <SalesBar
+                  key={lr.laptopId}
+                  label={getModelLabel(lr)}
+                  retailPrice={lr.retailPrice}
+                  unitsSold={lr.unitsSold}
+                  capacity={lr.unitsSold + lr.unsoldUnits}
+                  maxUnits={maxUnits}
+                  unsoldUnits={lr.unsoldUnits}
+                  progress={progress}
+                  isPlayer
+                />
+              ))}
+            </>
+          )}
+          {sortedCompResults.length > 0 && (
+            <>
+              <GroupLabel text="Competitors" />
+              {sortedCompResults.map((lr) => (
+                <SalesBar
+                  key={lr.laptopId}
+                  label={getModelLabel(lr)}
+                  retailPrice={lr.retailPrice}
+                  unitsSold={lr.unitsSold}
+                  capacity={lr.unitsSold + lr.unsoldUnits}
+                  maxUnits={maxUnits}
+                  unsoldUnits={lr.unsoldUnits}
+                  progress={progress}
+                  isPlayer={false}
+                />
+              ))}
+            </>
+          )}
+          {allSortedResults.length === 0 && (
             <div style={{ color: tokens.colors.textMuted, fontSize: tokens.font.sizeBase }}>
               No models on sale this quarter.
             </div>
           )}
         </div>
 
-        {/* Right: KPIs + headlines */}
-        <div style={{ width: 280, flexShrink: 0, display: "flex", flexDirection: "column", gap: tokens.spacing.lg }}>
-          {/* KPI counters */}
-          <div style={{
-            background: tokens.colors.cardBg,
-            border: `1px solid ${tokens.colors.panelBorder}`,
-            borderRadius: tokens.borderRadius.md,
-            padding: tokens.spacing.lg,
-            display: "flex",
-            flexDirection: "column",
-            gap: tokens.spacing.md,
-          }}>
-            <KpiCounter
-              label="Units Sold"
-              value={totalUnits}
-              progress={progress}
-              format={(n) => formatNumber(Math.round(n))}
-            />
-            <KpiCounter
-              label="Revenue"
-              value={result.totalRevenue}
-              progress={progress}
-              format={(n) => formatCash(Math.round(n))}
-              color={tokens.colors.success}
-            />
-            <KpiCounter
-              label="Profit"
-              value={result.totalProfit}
-              progress={progress}
-              format={(n) => formatCash(Math.round(n))}
-              color={result.totalProfit >= 0 ? tokens.colors.success : tokens.colors.danger}
-            />
-            <KpiCounter
-              label="Cash"
-              value={result.cashAfterResolution}
-              from={cashBefore}
-              progress={progress}
-              format={(n) => formatCash(Math.round(n))}
-              color={tokens.colors.statusCash}
-            />
-          </div>
+        {/* KPI Strip */}
+        <div style={{ marginTop: tokens.spacing.lg }}>
+          <KpiStrip
+            revenue={result.totalRevenue}
+            cash={result.cashAfterResolution}
+            cashBefore={cashBefore}
+            progress={progress}
+          />
+        </div>
 
-          {/* Headlines */}
+        {/* Headlines */}
+        {visibleHeadlines.length > 0 && (
           <div style={{
+            marginTop: tokens.spacing.md,
             display: "flex",
             flexDirection: "column",
             gap: tokens.spacing.sm,
-            minHeight: 80,
           }}>
             {visibleHeadlines.map((h) => (
               <HeadlineToast
                 key={h.triggerAt}
                 headline={h}
                 onDismiss={() => setVisibleHeadlines((prev) => prev.filter((x) => x !== h))}
+                onClick={() => openOverlay(h)}
               />
             ))}
           </div>
-        </div>
+        )}
       </div>
 
       {/* Footer */}
@@ -520,6 +714,11 @@ export function SimTickerScreen() {
           </button>
         )}
       </div>
+
+      {/* Headline article overlay */}
+      {overlayHeadline && (
+        <HeadlineOverlay headline={overlayHeadline} onClose={closeOverlay} />
+      )}
     </div>
   );
 }
@@ -568,13 +767,14 @@ const headerStyle: CSSProperties = {
   flexShrink: 0,
 };
 
-const contentAreaStyle: CSSProperties = {
+const columnStyle: CSSProperties = {
   flex: 1,
-  display: "flex",
-  gap: tokens.spacing.xl,
+  maxWidth: 900,
+  width: "100%",
+  margin: "0 auto",
   padding: `0 ${tokens.spacing.xl}px`,
-  minHeight: 0,
-  overflow: "hidden",
+  overflowY: "auto",
+  overflowX: "hidden",
 };
 
 const footerStyle: CSSProperties = {

--- a/src/renderer/state/GameContext.tsx
+++ b/src/renderer/state/GameContext.tsx
@@ -475,7 +475,13 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         ),
       };
     case "SET_REVIEWS": {
-      const reviewNews = generateReviewNews(action.reviews, state.year, state.quarter);
+      const alreadyReviewedIds = new Set(
+        state.newsHistory
+          .filter((n) => n.category === "review" && n.body?.type === "review")
+          .map((n) => (n.body as Extract<import("../../simulation/newsTypes").NewsBody, { type: "review" }>).laptopId),
+      );
+      const unreviewed = action.reviews.filter((r) => !alreadyReviewedIds.has(r.laptopId));
+      const reviewNews = generateReviewNews(unreviewed, state.year, state.quarter);
       return {
         ...state,
         currentYearReviews: action.reviews,

--- a/src/simulation/newsEngine.ts
+++ b/src/simulation/newsEngine.ts
@@ -364,6 +364,7 @@ export function generateReviewNews(
       headline: generateHeadline(REVIEW_TEMPLATES, outlet, vars),
       body: {
         type: "review",
+        laptopId: review.laptopId,
         laptopName: review.laptopName,
         outlet: review.outletName,
         score: review.score,

--- a/src/simulation/newsTypes.ts
+++ b/src/simulation/newsTypes.ts
@@ -46,7 +46,7 @@ export type NewsBody =
   | { type: "financial"; milestoneTitle: string }
   | { type: "marketShare"; demographic: string; share: number; threshold: number }
   | { type: "perception"; demographic: string; delta: number; direction: "up" | "down" }
-  | { type: "review"; laptopName: string; outlet: string; score: number; sentences: string[] }
+  | { type: "review"; laptopId: string; laptopName: string; outlet: string; score: number; sentences: string[] }
   | { type: "award"; category: string; winnerName: string; ownerName: string; runnerUpName?: string };
 
 export interface NewsItem {


### PR DESCRIPTION
## Summary

- **SimTickerScreen**: collapsed to single centered column (max-width 900px), full calendar date in progress bar, "Your Models" / "Competitors" group labels, sales bars show retail price + `X / Y sold` denominator, Revenue + Cash horizontal KPI strip, clickable headlines pause the sim and open a full article overlay
- **PreSimNewsScreen**: masthead dates use calendar format (e.g. "January 3, 2027"), dot indicator active state is now an 8px circle (no pill), launch articles have 2–3 paragraphs of outlet-specific editorial prose with drop caps, `consumerWeekly` reviews use a magazine card layout with per-category rating bars and pros/cons verdict, Market Snapshot upgraded to 2×3 grid (Models Competing, Price Range, Your Inventory, Seasonal Demand, Active Campaigns, Cash on Hand)
- `QuarterlySummaryScreen` untouched per spec

## What was decided / not obvious
- Pre-sim cash derived from `result.cashAfterResolution - result.totalRevenue + result.marketingCost` — no new GameState field needed
- Per-category review scores are deterministically generated from a hash of `laptopName` varying ±35% around the overall score — consistent across re-renders, no data model change
- Headline overlay body text is type-keyed static prose (4 variants) — ephemeral headlines don't map to stored NewsItems
- Editorial prose templates are inline in PreSimNewsScreen (not in newsTemplates.ts) since they're rendering-only, not stored in newsHistory

Closes #227
Closes #193